### PR TITLE
fix: broken header logo on small screens

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -12,12 +12,12 @@ const headerItems: Item[] = [
 <header
   class="flex h-navigation-bar items-center px-[4vw] mx-auto w-full max-w-[calc(1130px+8vw)]"
 >
-  <div class="flex flex-[2] items-center">
+  <div class="flex flex-2 items-center">
     <a
       href="/"
       class="text-lg font-extrabold text-slate-400 dark:text-neutral-200"
     >
-      Yagiz Nizipli
+      Yagiz <span class="hidden sm:inline">Nizipli</span>
       <span class="sr-only">Navigate to the homepage</span>
     </a>
   </div>
@@ -27,7 +27,7 @@ const headerItems: Item[] = [
       headerItems.map((item) => (
         <a
           href={item.href}
-          class="mx-4 font-bold text-slate-800 dark:text-zinc-200 hover:text-slate-600 text-sm"
+          class="mx-1 md:mx-4 text-sm font-bold text-slate-800 hover:text-slate-600 dark:text-zinc-200"
         >
           {item.title}
         </a>


### PR DESCRIPTION
Hey @anonrig, I've tweaked (hide `Nizipli` on small screens) the logo a bit make it fit on the small screens. Let me if this is okay. If you want to keep the logo `Yagiz Nizipli` on every screen I can make a hamburger menu or something for the menu items.

https://github.com/anonrig/yagiz.co/assets/50639499/1b17a67f-be79-4a5d-b025-794b2038253f

