### PR TITLE
Add .md endpoints for every page and blog post

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,16 +1,16 @@
+import { readdirSync, readFileSync } from 'node:fs'
 import cloudflare from '@astrojs/cloudflare'
 import mdx from '@astrojs/mdx'
 import sitemap from '@astrojs/sitemap'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig, fontProviders } from 'astro/config'
-import { readdirSync, readFileSync } from 'node:fs'
 import rehypeAutolinkHeadings, {
   type Options as RehypeAutolinkHeadingsOptions,
 } from 'rehype-autolink-headings'
 import rehypePrettyCode, { type Options as RehypePrettyCodeOptions } from 'rehype-pretty-code'
 import rehypeSlug from 'rehype-slug'
 import remarkGfm from 'remark-gfm'
-import { authorFullName, websiteUrl } from './src/lib/content.ts'
+import { websiteUrl } from './src/lib/content.ts'
 
 function listSlugs(dir: string): string[] {
   return readdirSync(dir)

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,13 +3,35 @@ import mdx from '@astrojs/mdx'
 import sitemap from '@astrojs/sitemap'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig, fontProviders } from 'astro/config'
+import { readdirSync, readFileSync } from 'node:fs'
 import rehypeAutolinkHeadings, {
   type Options as RehypeAutolinkHeadingsOptions,
 } from 'rehype-autolink-headings'
 import rehypePrettyCode, { type Options as RehypePrettyCodeOptions } from 'rehype-pretty-code'
 import rehypeSlug from 'rehype-slug'
 import remarkGfm from 'remark-gfm'
-import { websiteUrl } from './src/lib/content.ts'
+import { authorFullName, websiteUrl } from './src/lib/content.ts'
+
+function listSlugs(dir: string): string[] {
+  return readdirSync(dir)
+    .filter((f) => !f.startsWith('_'))
+    .map((f) => f.replace(/\.mdx?$/, ''))
+}
+
+function publishedBlogSlugs(): string[] {
+  const dir = './src/content/blog'
+  return readdirSync(dir)
+    .filter((f) => !f.startsWith('_'))
+    .filter((f) => readFileSync(`${dir}/${f}`, 'utf-8').includes('status: published'))
+    .map((f) => f.replace(/\.mdx?$/, ''))
+}
+
+const markdownPages: string[] = [
+  `${websiteUrl}/index.md`,
+  ...publishedBlogSlugs().map((slug) => `${websiteUrl}/${slug}.md`),
+  ...listSlugs('./src/content/pages').map((slug) => `${websiteUrl}/${slug}.md`),
+  ...listSlugs('./src/content/tags').map((slug) => `${websiteUrl}/tag/${slug}.md`),
+]
 
 // https://astro.build/config
 export default defineConfig({
@@ -94,6 +116,7 @@ export default defineConfig({
     }),
     sitemap({
       lastmod: new Date(),
+      customPages: markdownPages,
     }),
   ],
   vite: {

--- a/src/lib/to-markdown.ts
+++ b/src/lib/to-markdown.ts
@@ -1,4 +1,7 @@
 import type { CollectionEntry } from 'astro:content'
+import { authorFullName } from '@/lib/content'
+
+const FOOTER = `\n---\n\nAuthored by ${authorFullName}`
 
 export function postToMarkdown(post: CollectionEntry<'blog'>): string {
   const date = post.data.date.toISOString().split('T')[0]
@@ -12,11 +15,21 @@ export function postToMarkdown(post: CollectionEntry<'blog'>): string {
     '---',
     '',
     post.body ?? '',
+    FOOTER,
   ].join('\n')
 }
 
 export function pageToMarkdown(page: CollectionEntry<'pages'>): string {
-  return [`# ${page.data.title}`, '', `> ${page.data.description}`, '', '---', '', page.body ?? ''].join('\n')
+  return [
+    `# ${page.data.title}`,
+    '',
+    `> ${page.data.description}`,
+    '',
+    '---',
+    '',
+    page.body ?? '',
+    FOOTER,
+  ].join('\n')
 }
 
 export function tagToMarkdown(
@@ -38,5 +51,6 @@ export function tagToMarkdown(
     '---',
     '',
     postList,
+    FOOTER,
   ].join('\n')
 }

--- a/src/lib/to-markdown.ts
+++ b/src/lib/to-markdown.ts
@@ -1,0 +1,42 @@
+import type { CollectionEntry } from 'astro:content'
+
+export function postToMarkdown(post: CollectionEntry<'blog'>): string {
+  const date = post.data.date.toISOString().split('T')[0]
+  return [
+    `# ${post.data.title}`,
+    '',
+    `> ${post.data.description}`,
+    '',
+    `*Published: ${date} · Tag: ${post.data.tag.id}*`,
+    '',
+    '---',
+    '',
+    post.body ?? '',
+  ].join('\n')
+}
+
+export function pageToMarkdown(page: CollectionEntry<'pages'>): string {
+  return [`# ${page.data.title}`, '', `> ${page.data.description}`, '', '---', '', page.body ?? ''].join('\n')
+}
+
+export function tagToMarkdown(
+  tag: CollectionEntry<'tags'>,
+  posts: CollectionEntry<'blog'>[],
+): string {
+  const postList = posts
+    .map((p) => {
+      const date = p.data.date.toISOString().split('T')[0]
+      return `- [${p.data.title}](/${p.id}) — ${date}`
+    })
+    .join('\n')
+
+  return [
+    `# #${tag.data.title}`,
+    '',
+    `> ${tag.data.description}`,
+    '',
+    '---',
+    '',
+    postList,
+  ].join('\n')
+}

--- a/src/pages/[slug].md.ts
+++ b/src/pages/[slug].md.ts
@@ -1,0 +1,30 @@
+export const prerender = true
+
+import { type CollectionEntry, getCollection } from 'astro:content'
+import type { APIContext, GetStaticPaths } from 'astro'
+import { pageToMarkdown, postToMarkdown } from '@/lib/to-markdown'
+
+type Props =
+  | { type: 'post'; entry: CollectionEntry<'blog'> }
+  | { type: 'page'; entry: CollectionEntry<'pages'> }
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const [posts, pages] = await Promise.all([
+    getCollection('blog', ({ data }) => data.status === 'published'),
+    getCollection('pages'),
+  ])
+
+  return [
+    ...posts.map((entry) => ({ params: { slug: entry.id }, props: { type: 'post' as const, entry } })),
+    ...pages.map((entry) => ({ params: { slug: entry.id }, props: { type: 'page' as const, entry } })),
+  ]
+}
+
+export async function GET({ props }: APIContext) {
+  const { type, entry } = props as Props
+  const markdown = type === 'post' ? postToMarkdown(entry) : pageToMarkdown(entry)
+
+  return new Response(markdown, {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  })
+}

--- a/src/pages/[slug].md.ts
+++ b/src/pages/[slug].md.ts
@@ -15,8 +15,14 @@ export const getStaticPaths: GetStaticPaths = async () => {
   ])
 
   return [
-    ...posts.map((entry) => ({ params: { slug: entry.id }, props: { type: 'post' as const, entry } })),
-    ...pages.map((entry) => ({ params: { slug: entry.id }, props: { type: 'page' as const, entry } })),
+    ...posts.map((entry) => ({
+      params: { slug: entry.id },
+      props: { type: 'post' as const, entry },
+    })),
+    ...pages.map((entry) => ({
+      params: { slug: entry.id },
+      props: { type: 'page' as const, entry },
+    })),
   ]
 }
 

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -20,11 +20,13 @@ export const GET: APIRoute = async () => {
     '',
     `> ${websiteDescription}`,
     '',
-    `*By ${authorFullName}*`,
-    '',
     '---',
     '',
     postList,
+    '',
+    '---',
+    '',
+    `Authored by ${authorFullName}`,
   ].join('\n')
 
   return new Response(markdown, {

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -1,0 +1,33 @@
+export const prerender = true
+
+import { getCollection } from 'astro:content'
+import type { APIRoute } from 'astro'
+import { authorFullName, websiteDescription, websiteTitle } from '@/lib/content'
+
+export const GET: APIRoute = async () => {
+  const posts = await getCollection('blog', ({ data }) => data.status === 'published')
+  posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+
+  const postList = posts
+    .map((post) => {
+      const date = post.data.date.toISOString().split('T')[0]
+      return `- [${post.data.title}](/${post.id}) — ${date}`
+    })
+    .join('\n')
+
+  const markdown = [
+    `# ${websiteTitle}`,
+    '',
+    `> ${websiteDescription}`,
+    '',
+    `*By ${authorFullName}*`,
+    '',
+    '---',
+    '',
+    postList,
+  ].join('\n')
+
+  return new Response(markdown, {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  })
+}

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -4,6 +4,15 @@ import { getCollection } from 'astro:content'
 import type { APIRoute } from 'astro'
 import { authorFullName, websiteDescription, websiteTitle, websiteUrl } from '@/lib/content'
 
+function toAscii(str: string): string {
+  return str
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/[\u2013\u2014]/g, '-')
+    .replace(/\u2026/g, '...')
+    .replace(/[^\x00-\x7F]/g, '')
+}
+
 export const GET: APIRoute = async () => {
   const posts = await getCollection('blog', ({ data }) => data.status === 'published')
   posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
@@ -11,7 +20,7 @@ export const GET: APIRoute = async () => {
   const postLinks = posts
     .map((post) => {
       const date = post.data.date.toISOString().split('T')[0]
-      return `- [${post.data.title}](${websiteUrl}/${post.id}.md): ${post.data.description} (${date})`
+      return `- [${toAscii(post.data.title)}](${websiteUrl}/${post.id}.md): ${toAscii(post.data.description)} (${date})`
     })
     .join('\n')
 

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -4,15 +4,6 @@ import { getCollection } from 'astro:content'
 import type { APIRoute } from 'astro'
 import { authorFullName, websiteDescription, websiteTitle, websiteUrl } from '@/lib/content'
 
-function toAscii(str: string): string {
-  return str
-    .replace(/[\u2018\u2019]/g, "'")
-    .replace(/[\u201C\u201D]/g, '"')
-    .replace(/[\u2013\u2014]/g, '-')
-    .replace(/\u2026/g, '...')
-    .replace(/[^\x00-\x7F]/g, '')
-}
-
 export const GET: APIRoute = async () => {
   const posts = await getCollection('blog', ({ data }) => data.status === 'published')
   posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
@@ -20,7 +11,7 @@ export const GET: APIRoute = async () => {
   const postLinks = posts
     .map((post) => {
       const date = post.data.date.toISOString().split('T')[0]
-      return `- [${toAscii(post.data.title)}](${websiteUrl}/${post.id}.md): ${toAscii(post.data.description)} (${date})`
+      return `- [${post.data.title}](${websiteUrl}/${post.id}.md): ${post.data.description} (${date})`
     })
     .join('\n')
 

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,42 @@
+export const prerender = true
+
+import { getCollection } from 'astro:content'
+import type { APIRoute } from 'astro'
+import { authorFullName, websiteDescription, websiteTitle, websiteUrl } from '@/lib/content'
+
+export const GET: APIRoute = async () => {
+  const posts = await getCollection('blog', ({ data }) => data.status === 'published')
+  posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+
+  const postLinks = posts
+    .map((post) => {
+      const date = post.data.date.toISOString().split('T')[0]
+      return `- [${post.data.title}](${websiteUrl}/${post.id}.md): ${post.data.description} (${date})`
+    })
+    .join('\n')
+
+  const content = [
+    `# ${websiteTitle}`,
+    '',
+    `> ${websiteDescription}`,
+    '',
+    '## Pages',
+    '',
+    `- [About](${websiteUrl}/about.md): Background, work history, and open source contributions by ${authorFullName}`,
+    `- [Press](${websiteUrl}/press.md): Articles, interviews, presentations, and podcast appearances featuring ${authorFullName}`,
+    `- [Newsletter](${websiteUrl}/newsletter.md): Subscribe to get new posts delivered by email`,
+    '',
+    '## Blog Posts',
+    '',
+    postLinks,
+    '',
+    '## Optional',
+    '',
+    `- [Contact](${websiteUrl}/contact.md): Get in touch with ${authorFullName}`,
+    `- [RSS feed](${websiteUrl}/rss.xml): Full RSS feed of all published posts`,
+  ].join('\n')
+
+  return new Response(content, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  })
+}

--- a/src/pages/tag/[id].md.ts
+++ b/src/pages/tag/[id].md.ts
@@ -1,0 +1,23 @@
+export const prerender = true
+
+import { type CollectionEntry, getCollection } from 'astro:content'
+import type { APIContext, GetStaticPaths } from 'astro'
+import { tagToMarkdown } from '@/lib/to-markdown'
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const tags = await getCollection('tags')
+  return tags.map((tag) => ({ params: { id: tag.id }, props: { tag } }))
+}
+
+export async function GET({ props, params }: APIContext) {
+  const tag = props.tag as CollectionEntry<'tags'>
+  const posts = await getCollection(
+    'blog',
+    ({ data }) => data.status === 'published' && data.tag.id === params.id,
+  )
+  posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+
+  return new Response(tagToMarkdown(tag, posts), {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  })
+}


### PR DESCRIPTION
Each page and blog post now has a markdown representation accessible by
appending .md to the URL (e.g. /press.md, /announcing-ada-url-parser-v2-0.md).

- src/lib/to-markdown.ts: shared helpers to format posts, pages, and tag pages as markdown
- src/pages/[slug].md.ts: single dynamic endpoint covering all blog posts + pages collection entries
- src/pages/index.md.ts: homepage listing of all published posts as markdown
- src/pages/tag/[id].md.ts: per-tag post listing as markdown

https://claude.ai/code/session_01AUM9xFtXMir3Z1GThs8K2Y