### PR TITLE
Make the blog more LLM-friendly

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -34,6 +34,15 @@ const markdownPages: string[] = [
   ...listSlugs('./src/content/tags').map((slug) => `${websiteUrl}/tag/${slug}.md`),
 ]
 
+function isMarkdownOrLlmsAsset(page: string): boolean {
+  return (
+    page.endsWith('.md') ||
+    page.endsWith('/llms.txt') ||
+    page.endsWith('/llms-full.txt') ||
+    markdownPages.includes(page)
+  )
+}
+
 // https://astro.build/config
 export default defineConfig({
   // Keep previous HTML-aware whitespace handling (v7 defaults to JSX rules).
@@ -125,7 +134,8 @@ export default defineConfig({
     }),
     sitemap({
       lastmod: new Date(),
-      customPages: markdownPages,
+      // Markdown / llms endpoints are for agents; keep them out of the HTML sitemap.
+      filter: (page) => !isMarkdownOrLlmsAsset(page),
     }),
   ],
   vite: {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,9 @@
 User-agent: *
 Allow: /
 
+# LLM-oriented discovery
+# https://www.yagiz.co/llms.txt
+# https://www.yagiz.co/llms-full.txt
+
 Host: https://www.yagiz.co
 Sitemap: https://www.yagiz.co/sitemap-index.xml

--- a/src/components/MarkdownLink.astro
+++ b/src/components/MarkdownLink.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  href: string
+  class?: string
+}
+
+const { href, class: className } = Astro.props
+---
+
+<a
+  href={href}
+  class:list={[
+    'text-xs font-bold text-neutral-500 hover:text-neutral-400 dark:text-neutral-500 dark:hover:text-neutral-400',
+    className,
+  ]}
+>
+  View as Markdown
+</a>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,12 +10,15 @@ import {
   websiteDescription,
   websiteTitle,
 } from '@/lib/content'
+import type { JsonLd } from '@/lib/schema'
 import '@/styles/globals.css'
 
 interface Props {
   title?: string
   description?: string
   image?: string
+  markdownUrl?: string
+  jsonLd?: JsonLd | JsonLd[]
   article?: {
     authors?: string[]
     publishedTime?: string
@@ -28,10 +31,13 @@ const {
   title,
   description = websiteDescription,
   image = `${Astro.url.origin}/opengraph-image.png`,
+  markdownUrl,
+  jsonLd,
   article,
 } = Astro.props
 
 const pageTitle = title ? `${title} - ${websiteTitle}` : websiteTitle
+const jsonLdDocuments = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : []
 ---
 
 <html lang="en" class="bg-white text-black dark:bg-white-reversed">
@@ -91,8 +97,28 @@ const pageTitle = title ? `${title} - ${websiteTitle}` : websiteTitle
       type="image/png"
       sizes="180x180"
     />
+    {
+      markdownUrl && (
+        <link
+          rel="alternate"
+          type="text/markdown"
+          title="Markdown"
+          href={markdownUrl}
+        />
+      )
+    }
+    {
+      jsonLdDocuments.map((document) => (
+        <script
+          type="application/ld+json"
+          set:html={JSON.stringify(document)}
+          is:inline
+        />
+      ))
+    }
     <slot name="head" />
     <link rel="alternate" type="application/rss+xml" title={websiteTitle} href={new URL("/rss.xml", Astro.site)} />
+    <link rel="alternate" type="text/plain" title="llms.txt" href={new URL("/llms.txt", Astro.site)} />
   </head>
   <body>
     <a

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,187 @@
+import type { CollectionEntry } from 'astro:content'
+import {
+  authorFullName,
+  authorJobTitle,
+  githubImage,
+  twitterUsername,
+  websiteDescription,
+  websiteTitle,
+  websiteUrl,
+} from '@/lib/content'
+
+export type JsonLd = Record<string, unknown>
+
+const personId = `${websiteUrl}/#person`
+const websiteId = `${websiteUrl}/#website`
+const blogId = `${websiteUrl}/#blog`
+
+export function absoluteUrl(path = '/'): string {
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path
+  }
+  return new URL(path.startsWith('/') ? path : `/${path}`, websiteUrl).href
+}
+
+export function personJsonLd(): JsonLd {
+  return {
+    '@type': 'Person',
+    '@id': personId,
+    name: authorFullName,
+    url: websiteUrl,
+    image: githubImage,
+    jobTitle: authorJobTitle,
+    description: websiteDescription,
+    sameAs: ['https://github.com/anonrig', `https://x.com/${twitterUsername}`],
+  }
+}
+
+export function websiteJsonLd(): JsonLd {
+  return {
+    '@type': 'WebSite',
+    '@id': websiteId,
+    url: websiteUrl,
+    name: websiteTitle,
+    description: websiteDescription,
+    inLanguage: 'en-US',
+    publisher: { '@id': personId },
+    author: { '@id': personId },
+  }
+}
+
+export function blogJsonLd(posts: CollectionEntry<'blog'>[]): JsonLd {
+  return {
+    '@type': 'Blog',
+    '@id': blogId,
+    url: websiteUrl,
+    name: websiteTitle,
+    description: websiteDescription,
+    inLanguage: 'en-US',
+    publisher: { '@id': personId },
+    author: { '@id': personId },
+    blogPost: posts.map((post) => ({
+      '@type': 'BlogPosting',
+      '@id': absoluteUrl(`/${post.id}`),
+      headline: post.data.title,
+      url: absoluteUrl(`/${post.id}`),
+      datePublished: post.data.date.toISOString().split('T')[0],
+      description: post.data.description,
+      author: { '@id': personId },
+    })),
+  }
+}
+
+export function homeJsonLd(posts: CollectionEntry<'blog'>[]): JsonLd {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [personJsonLd(), websiteJsonLd(), blogJsonLd(posts)],
+  }
+}
+
+export function blogPostingJsonLd(
+  post: CollectionEntry<'blog'>,
+  tag: CollectionEntry<'tags'>,
+): JsonLd {
+  const url = absoluteUrl(`/${post.id}`)
+  const date = post.data.date.toISOString().split('T')[0]
+  const words = (post.body ?? '').trim().split(/\s+/).filter(Boolean).length
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      personJsonLd(),
+      websiteJsonLd(),
+      {
+        '@type': 'BlogPosting',
+        '@id': url,
+        mainEntityOfPage: {
+          '@type': 'WebPage',
+          '@id': url,
+        },
+        headline: post.data.title,
+        description: post.data.description,
+        url,
+        image: absoluteUrl(`/${post.id}/opengraph-image.png`),
+        datePublished: date,
+        dateModified: date,
+        inLanguage: 'en-US',
+        author: { '@id': personId },
+        publisher: { '@id': personId },
+        keywords: tag.data.title,
+        articleSection: tag.data.title,
+        wordCount: words,
+        isPartOf: { '@id': blogId },
+        speakable: {
+          '@type': 'SpeakableSpecification',
+          cssSelector: ['article h1', 'article.prose'],
+        },
+      },
+    ],
+  }
+}
+
+export function tagCollectionJsonLd(
+  tag: CollectionEntry<'tags'>,
+  posts: CollectionEntry<'blog'>[],
+): JsonLd {
+  const url = absoluteUrl(`/tag/${tag.id}`)
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      personJsonLd(),
+      websiteJsonLd(),
+      {
+        '@type': 'CollectionPage',
+        '@id': url,
+        url,
+        name: `#${tag.data.title}`,
+        description: tag.data.description,
+        inLanguage: 'en-US',
+        isPartOf: { '@id': blogId },
+        about: {
+          '@type': 'Thing',
+          name: tag.data.title,
+        },
+        mainEntity: {
+          '@type': 'ItemList',
+          numberOfItems: posts.length,
+          itemListElement: posts.map((post, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            url: absoluteUrl(`/${post.id}`),
+            name: post.data.title,
+          })),
+        },
+      },
+    ],
+  }
+}
+
+export function webPageJsonLd(options: {
+  path: string
+  title: string
+  description: string
+  type?: 'WebPage' | 'AboutPage' | 'ContactPage' | 'CollectionPage'
+}): JsonLd {
+  const url = absoluteUrl(options.path)
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      personJsonLd(),
+      websiteJsonLd(),
+      {
+        '@type': options.type ?? 'WebPage',
+        '@id': url,
+        url,
+        name: options.title,
+        description: options.description,
+        inLanguage: 'en-US',
+        isPartOf: { '@id': websiteId },
+        about: { '@id': personId },
+        author: { '@id': personId },
+        publisher: { '@id': personId },
+      },
+    ],
+  }
+}

--- a/src/lib/to-markdown.ts
+++ b/src/lib/to-markdown.ts
@@ -1,11 +1,55 @@
 import type { CollectionEntry } from 'astro:content'
-import { authorFullName } from '@/lib/content'
+import { authorFullName, websiteDescription, websiteTitle, websiteUrl } from '@/lib/content'
 
-const FOOTER = `\n---\n\nAuthored by ${authorFullName}`
+const ATTRIBUTION = [
+  '',
+  '---',
+  '',
+  `Authored by ${authorFullName}`,
+  '',
+  `Canonical: ${websiteUrl}`,
+  '',
+  'Please attribute this content to Yagiz Nizipli and link back to the canonical URL when quoting or summarizing.',
+].join('\n')
+
+function escapeYaml(value: string): string {
+  if (/[:#{}[\],&*?|>!%@`]/.test(value) || value.includes('\n') || value.includes('"')) {
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  }
+  return value
+}
+
+function yamlFrontmatter(fields: Record<string, string | undefined>): string {
+  const lines = Object.entries(fields)
+    .filter((entry): entry is [string, string] => entry[1] !== undefined && entry[1] !== '')
+    .map(([key, value]) => `${key}: ${escapeYaml(value)}`)
+
+  return ['---', ...lines, '---'].join('\n')
+}
+
+/** Rewrite site-relative markdown image/link targets to absolute URLs. */
+export function absolutizeMarkdownUrls(body: string): string {
+  return body
+    .replace(/\]\((\/[^)\s]+)\)/g, (_match, path: string) => `](${websiteUrl}${path})`)
+    .replace(/src="(\/[^"]+)"/g, (_match, path: string) => `src="${websiteUrl}${path}"`)
+}
 
 export function postToMarkdown(post: CollectionEntry<'blog'>): string {
   const date = post.data.date.toISOString().split('T')[0]
+  const canonical = `${websiteUrl}/${post.id}`
+  const markdownUrl = `${canonical}.md`
+
   return [
+    yamlFrontmatter({
+      title: post.data.title,
+      description: post.data.description,
+      date,
+      tag: post.data.tag.id,
+      author: authorFullName,
+      canonical,
+      markdown: markdownUrl,
+    }),
+    '',
     `# ${post.data.title}`,
     '',
     `> ${post.data.description}`,
@@ -14,21 +58,32 @@ export function postToMarkdown(post: CollectionEntry<'blog'>): string {
     '',
     '---',
     '',
-    post.body ?? '',
-    FOOTER,
+    absolutizeMarkdownUrls(post.body ?? ''),
+    ATTRIBUTION.replace(`Canonical: ${websiteUrl}`, `Canonical: ${canonical}`),
   ].join('\n')
 }
 
 export function pageToMarkdown(page: CollectionEntry<'pages'>): string {
+  const canonical = `${websiteUrl}/${page.id}`
+  const markdownUrl = `${canonical}.md`
+
   return [
+    yamlFrontmatter({
+      title: page.data.title,
+      description: page.data.description,
+      author: authorFullName,
+      canonical,
+      markdown: markdownUrl,
+    }),
+    '',
     `# ${page.data.title}`,
     '',
     `> ${page.data.description}`,
     '',
     '---',
     '',
-    page.body ?? '',
-    FOOTER,
+    absolutizeMarkdownUrls(page.body ?? ''),
+    ATTRIBUTION.replace(`Canonical: ${websiteUrl}`, `Canonical: ${canonical}`),
   ].join('\n')
 }
 
@@ -36,14 +91,25 @@ export function tagToMarkdown(
   tag: CollectionEntry<'tags'>,
   posts: CollectionEntry<'blog'>[],
 ): string {
+  const canonical = `${websiteUrl}/tag/${tag.id}`
+  const markdownUrl = `${canonical}.md`
+
   const postList = posts
     .map((p) => {
       const date = p.data.date.toISOString().split('T')[0]
-      return `- [${p.data.title}](/${p.id}) — ${date}`
+      return `- [${p.data.title}](${websiteUrl}/${p.id}.md) — ${date}`
     })
     .join('\n')
 
   return [
+    yamlFrontmatter({
+      title: `#${tag.data.title}`,
+      description: tag.data.description,
+      author: authorFullName,
+      canonical,
+      markdown: markdownUrl,
+    }),
+    '',
     `# #${tag.data.title}`,
     '',
     `> ${tag.data.description}`,
@@ -51,6 +117,44 @@ export function tagToMarkdown(
     '---',
     '',
     postList,
-    FOOTER,
+    ATTRIBUTION.replace(`Canonical: ${websiteUrl}`, `Canonical: ${canonical}`),
   ].join('\n')
+}
+
+export function homeToMarkdown(posts: CollectionEntry<'blog'>[]): string {
+  const postList = posts
+    .map((post) => {
+      const date = post.data.date.toISOString().split('T')[0]
+      return `- [${post.data.title}](${websiteUrl}/${post.id}.md) — ${date}`
+    })
+    .join('\n')
+
+  return [
+    yamlFrontmatter({
+      title: websiteTitle,
+      description: websiteDescription,
+      author: authorFullName,
+      canonical: websiteUrl,
+      markdown: `${websiteUrl}/index.md`,
+    }),
+    '',
+    `# ${websiteTitle}`,
+    '',
+    `> ${websiteDescription}`,
+    '',
+    '---',
+    '',
+    postList,
+    ATTRIBUTION,
+  ].join('\n')
+}
+
+export function markdownResponse(body: string, canonicalHtmlUrl: string): Response {
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'X-Robots-Tag': 'noindex, nofollow',
+      Link: `<${canonicalHtmlUrl}>; rel="canonical"`,
+    },
+  })
 }

--- a/src/pages/[id]/index.astro
+++ b/src/pages/[id]/index.astro
@@ -5,13 +5,15 @@ import type { GetStaticPaths } from 'astro'
 import BlogFooter from '@/components/BlogFooter.astro'
 import BlogRow from '@/components/BlogRow.astro'
 import BlogStickyHeader from '@/components/BlogStickyHeader.astro'
+import MarkdownLink from '@/components/MarkdownLink.astro'
 import { components } from '@/components/mdx'
 import Container from '@/components/ui/Container.astro'
 import Figure from '@/components/ui/Figure.astro'
 import Heading from '@/components/ui/Heading.astro'
 import Prose from '@/components/ui/Prose.astro'
 import Layout from '@/layouts/Layout.astro'
-import { authorFullName } from '@/lib/content'
+import { authorFullName, websiteUrl } from '@/lib/content'
+import { blogPostingJsonLd } from '@/lib/schema'
 
 interface Props {
   post: CollectionEntry<'blog'>
@@ -43,44 +45,22 @@ const suggestions = [posts.at(index - 2), posts.at(index - 1)].filter(
   Boolean,
 ) as CollectionEntry<'blog'>[]
 const publishedTime = post.data.date.toISOString().split('T')[0]
-const modifiedTime = new Date().toISOString().split('T')[0]
-
-const structuredData = {
-  '@context': 'https://schema.org',
-  '@type': 'Article',
-  mainEntityOfPage: {
-    '@type': 'WebPage',
-    '@id': `${Astro.url.origin}/${post.id}`,
-  },
-  headline: post.data.title,
-  image: [`${Astro.url.origin}/${post.id}/opengraph-image.png`],
-  datePublished: publishedTime,
-  dateModified: modifiedTime,
-  author: {
-    '@type': 'Person',
-    name: authorFullName,
-  },
-}
+const markdownUrl = `${websiteUrl}/${post.id}.md`
 ---
 
 <Layout
   title={post.data.title}
   description={post.data.description}
   image={`${Astro.url.origin}/${post.id}/opengraph-image.png`}
+  markdownUrl={markdownUrl}
+  jsonLd={blogPostingJsonLd(post, tag)}
   article={{
     authors: [authorFullName],
     publishedTime,
-    modifiedTime,
+    modifiedTime: publishedTime,
     tags: [tag.data.title],
   }}
 >
-  <Fragment slot="head">
-    <script
-      type="application/ld+json"
-      set:html={JSON.stringify(structuredData)}
-      is:inline
-    />
-  </Fragment>
   <article>
     <header class="mb-6 grid grid-cols-canvas text-center">
       <div
@@ -108,6 +88,9 @@ const structuredData = {
             {tag.data.title}
           </a>
         </span>
+      </div>
+      <div class="col-main mb-4">
+        <MarkdownLink href={markdownUrl} />
       </div>
 
       <Heading>{post.data.title}</Heading>

--- a/src/pages/[slug].md.ts
+++ b/src/pages/[slug].md.ts
@@ -2,7 +2,8 @@ export const prerender = true
 
 import { type CollectionEntry, getCollection } from 'astro:content'
 import type { APIContext, GetStaticPaths } from 'astro'
-import { pageToMarkdown, postToMarkdown } from '@/lib/to-markdown'
+import { websiteUrl } from '@/lib/content'
+import { markdownResponse, pageToMarkdown, postToMarkdown } from '@/lib/to-markdown'
 
 type Props =
   | { type: 'post'; entry: CollectionEntry<'blog'> }
@@ -29,8 +30,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export async function GET({ props }: APIContext) {
   const { type, entry } = props as Props
   const markdown = type === 'post' ? postToMarkdown(entry) : pageToMarkdown(entry)
+  const canonical = `${websiteUrl}/${entry.id}`
 
-  return new Response(markdown, {
-    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
-  })
+  return markdownResponse(markdown, canonical)
 }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,13 +1,31 @@
 ---
 import { getEntry } from 'astro:content'
+import MarkdownLink from '@/components/MarkdownLink.astro'
 import Page from '@/components/Page.astro'
 import Layout from '@/layouts/Layout.astro'
+import { websiteUrl } from '@/lib/content'
+import { webPageJsonLd } from '@/lib/schema'
 
 const page = await getEntry('pages', 'about')
 if (!page) {
   throw new Error('Page not found')
 }
+
+const markdownUrl = `${websiteUrl}/about.md`
 ---
-<Layout title={page.data.title} description={page.data.description}>
+<Layout
+  title={page.data.title}
+  description={page.data.description}
+  markdownUrl={markdownUrl}
+  jsonLd={webPageJsonLd({
+    path: '/about',
+    title: page.data.title,
+    description: page.data.description,
+    type: 'AboutPage',
+  })}
+>
   <Page {page} />
+  <div class="mx-auto mt-8 max-w-[calc(750px+8vw)] px-[4vw] text-center">
+    <MarkdownLink href={markdownUrl} />
+  </div>
 </Layout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,17 +1,35 @@
 ---
 import { getEntry } from 'astro:content'
 import ContactForm from '@/components/ContactForm.astro'
+import MarkdownLink from '@/components/MarkdownLink.astro'
 import Page from '@/components/Page.astro'
 import Layout from '@/layouts/Layout.astro'
+import { websiteUrl } from '@/lib/content'
+import { webPageJsonLd } from '@/lib/schema'
 
 const page = await getEntry('pages', 'contact')
 if (!page) {
   throw new Error('Page not found')
 }
+
+const markdownUrl = `${websiteUrl}/contact.md`
 ---
 
-<Layout title={page.data.title} description={page.data.description}>
+<Layout
+  title={page.data.title}
+  description={page.data.description}
+  markdownUrl={markdownUrl}
+  jsonLd={webPageJsonLd({
+    path: '/contact',
+    title: page.data.title,
+    description: page.data.description,
+    type: 'ContactPage',
+  })}
+>
   <Page {page}>
     <ContactForm />
   </Page>
+  <div class="mx-auto mt-8 max-w-[calc(750px+8vw)] px-[4vw] text-center">
+    <MarkdownLink href={markdownUrl} />
+  </div>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,9 +3,12 @@ import { Image } from 'astro:assets'
 import { getCollection } from 'astro:content'
 import familyImg from '@/assets/family.png'
 import BlogRow from '@/components/BlogRow.astro'
+import MarkdownLink from '@/components/MarkdownLink.astro'
 import SubscribeButton from '@/components/SubscribeButton.astro'
 import Container from '@/components/ui/Container.astro'
 import Layout from '@/layouts/Layout.astro'
+import { websiteUrl } from '@/lib/content'
+import { homeJsonLd } from '@/lib/schema'
 
 const posts = await getCollection('blog', ({ data }) => data.status === 'published')
 posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
@@ -19,9 +22,10 @@ const postsByYear = posts.reduce((acc, post) => {
 }, new Map<number, typeof posts>())
 
 const years = [...postsByYear.keys()]
+const markdownUrl = `${websiteUrl}/index.md`
 ---
 
-<Layout>
+<Layout markdownUrl={markdownUrl} jsonLd={homeJsonLd(posts)}>
     <div class="-mt-8 mx-auto mb-4 flex max-w-lg flex-col items-center text-center">
       <div class="relative mb-8">
         <Image
@@ -41,6 +45,7 @@ const years = [...postsByYear.keys()]
       </div>
 
       <SubscribeButton />
+      <MarkdownLink href={markdownUrl} class="mt-4" />
     </div>
   <div class="pt-8">
     {years.map((year) => (

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -2,34 +2,12 @@ export const prerender = true
 
 import { getCollection } from 'astro:content'
 import type { APIRoute } from 'astro'
-import { authorFullName, websiteDescription, websiteTitle } from '@/lib/content'
+import { websiteUrl } from '@/lib/content'
+import { homeToMarkdown, markdownResponse } from '@/lib/to-markdown'
 
 export const GET: APIRoute = async () => {
   const posts = await getCollection('blog', ({ data }) => data.status === 'published')
   posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
 
-  const postList = posts
-    .map((post) => {
-      const date = post.data.date.toISOString().split('T')[0]
-      return `- [${post.data.title}](/${post.id}) — ${date}`
-    })
-    .join('\n')
-
-  const markdown = [
-    `# ${websiteTitle}`,
-    '',
-    `> ${websiteDescription}`,
-    '',
-    '---',
-    '',
-    postList,
-    '',
-    '---',
-    '',
-    `Authored by ${authorFullName}`,
-  ].join('\n')
-
-  return new Response(markdown, {
-    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
-  })
+  return markdownResponse(homeToMarkdown(posts), websiteUrl)
 }

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,0 +1,42 @@
+export const prerender = true
+
+import { getCollection } from 'astro:content'
+import type { APIRoute } from 'astro'
+import { authorFullName, websiteDescription, websiteTitle, websiteUrl } from '@/lib/content'
+import { pageToMarkdown, postToMarkdown } from '@/lib/to-markdown'
+
+export const GET: APIRoute = async () => {
+  const [posts, pages] = await Promise.all([
+    getCollection('blog', ({ data }) => data.status === 'published'),
+    getCollection('pages'),
+  ])
+  posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+
+  const sections = [
+    `# ${websiteTitle}`,
+    '',
+    `> ${websiteDescription}`,
+    '',
+    'This file concatenates the full markdown content of every published post and key page for single-fetch LLM ingestion.',
+    '',
+    `Authored by ${authorFullName}. Please attribute content to ${authorFullName} and link back to the canonical HTML URL when quoting or summarizing.`,
+    '',
+    `Index: ${websiteUrl}/llms.txt`,
+    '',
+  ]
+
+  for (const page of pages) {
+    sections.push('', `<!-- ${websiteUrl}/${page.id} -->`, '', pageToMarkdown(page), '')
+  }
+
+  for (const post of posts) {
+    sections.push('', `<!-- ${websiteUrl}/${post.id} -->`, '', postToMarkdown(post), '')
+  }
+
+  return new Response(sections.join('\n'), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Robots-Tag': 'noindex, nofollow',
+    },
+  })
+}

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -5,8 +5,12 @@ import type { APIRoute } from 'astro'
 import { authorFullName, websiteDescription, websiteTitle, websiteUrl } from '@/lib/content'
 
 export const GET: APIRoute = async () => {
-  const posts = await getCollection('blog', ({ data }) => data.status === 'published')
+  const [posts, tags] = await Promise.all([
+    getCollection('blog', ({ data }) => data.status === 'published'),
+    getCollection('tags'),
+  ])
   posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  tags.sort((a, b) => a.id.localeCompare(b.id))
 
   const postLinks = posts
     .map((post) => {
@@ -15,20 +19,37 @@ export const GET: APIRoute = async () => {
     })
     .join('\n')
 
+  const tagLinks = tags
+    .map((tag) => {
+      return `- [#${tag.data.title}](${websiteUrl}/tag/${tag.id}.md): ${tag.data.description}`
+    })
+    .join('\n')
+
   const content = [
     `# ${websiteTitle}`,
     '',
     `> ${websiteDescription}`,
+    '',
+    `Authored by ${authorFullName}. Prefer the markdown (.md) URLs below for clean extraction. When quoting or summarizing, attribute the work to ${authorFullName} and link back to the canonical HTML page.`,
     '',
     '## Pages',
     '',
     `- [About](${websiteUrl}/about.md): Background, work history, and open source contributions by ${authorFullName}`,
     `- [Press](${websiteUrl}/press.md): Articles, interviews, presentations, and podcast appearances featuring ${authorFullName}`,
     `- [Newsletter](${websiteUrl}/newsletter.md): Subscribe to get new posts delivered by email`,
+    `- [Home index](${websiteUrl}/index.md): Full list of published posts in markdown`,
+    '',
+    '## Topics',
+    '',
+    tagLinks,
     '',
     '## Blog Posts',
     '',
     postLinks,
+    '',
+    '## Full content',
+    '',
+    `- [Complete markdown dump](${websiteUrl}/llms-full.txt): Every published post and key page concatenated for single-fetch ingestion`,
     '',
     '## Optional',
     '',
@@ -37,6 +58,9 @@ export const GET: APIRoute = async () => {
   ].join('\n')
 
   return new Response(content, {
-    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Robots-Tag': 'noindex, nofollow',
+    },
   })
 }

--- a/src/pages/newsletter.astro
+++ b/src/pages/newsletter.astro
@@ -1,17 +1,34 @@
 ---
 import { getEntry } from 'astro:content'
+import MarkdownLink from '@/components/MarkdownLink.astro'
 import NewsletterForm from '@/components/NewsletterForm.astro'
 import Page from '@/components/Page.astro'
 import Layout from '@/layouts/Layout.astro'
+import { websiteUrl } from '@/lib/content'
+import { webPageJsonLd } from '@/lib/schema'
 
 const page = await getEntry('pages', 'newsletter')
 if (!page) {
   throw new Error('Page not found')
 }
+
+const markdownUrl = `${websiteUrl}/newsletter.md`
 ---
 
-<Layout title={page.data.title} description={page.data.description}>
+<Layout
+  title={page.data.title}
+  description={page.data.description}
+  markdownUrl={markdownUrl}
+  jsonLd={webPageJsonLd({
+    path: '/newsletter',
+    title: page.data.title,
+    description: page.data.description,
+  })}
+>
   <Page {page}>
     <NewsletterForm />
   </Page>
+  <div class="mx-auto mt-8 max-w-[calc(750px+8vw)] px-[4vw] text-center">
+    <MarkdownLink href={markdownUrl} />
+  </div>
 </Layout>

--- a/src/pages/press.astro
+++ b/src/pages/press.astro
@@ -1,14 +1,32 @@
 ---
 import { getEntry } from 'astro:content'
+import MarkdownLink from '@/components/MarkdownLink.astro'
 import Page from '@/components/Page.astro'
 import Layout from '@/layouts/Layout.astro'
+import { websiteUrl } from '@/lib/content'
+import { webPageJsonLd } from '@/lib/schema'
 
 const page = await getEntry('pages', 'press')
 
 if (!page) {
   throw new Error('Page not found')
 }
+
+const markdownUrl = `${websiteUrl}/press.md`
 ---
-<Layout title={page.data.title} description={page.data.description}>
+<Layout
+  title={page.data.title}
+  description={page.data.description}
+  markdownUrl={markdownUrl}
+  jsonLd={webPageJsonLd({
+    path: '/press',
+    title: page.data.title,
+    description: page.data.description,
+    type: 'CollectionPage',
+  })}
+>
   <Page {page} />
+  <div class="mx-auto mt-8 max-w-[calc(750px+8vw)] px-[4vw] text-center">
+    <MarkdownLink href={markdownUrl} />
+  </div>
 </Layout>

--- a/src/pages/tag/[id].astro
+++ b/src/pages/tag/[id].astro
@@ -3,8 +3,11 @@ import type { CollectionEntry } from 'astro:content'
 import { getCollection } from 'astro:content'
 import type { GetStaticPaths } from 'astro'
 import BlogRow from '@/components/BlogRow.astro'
+import MarkdownLink from '@/components/MarkdownLink.astro'
 import Container from '@/components/ui/Container.astro'
 import Layout from '@/layouts/Layout.astro'
+import { websiteUrl } from '@/lib/content'
+import { tagCollectionJsonLd } from '@/lib/schema'
 
 interface Props {
   tag: CollectionEntry<'tags'>
@@ -25,9 +28,15 @@ const posts = await getCollection(
   ({ data }) => data.status === 'published' && data.tag.id === tag.id,
 )
 posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+const markdownUrl = `${websiteUrl}/tag/${tag.id}.md`
 ---
 
-<Layout title={tag.data.title} description={tag.data.description}>
+<Layout
+  title={tag.data.title}
+  description={tag.data.description}
+  markdownUrl={markdownUrl}
+  jsonLd={tagCollectionJsonLd(tag, posts)}
+>
   <section>
     <Container size="tight" class="mx-auto -mt-6 flex flex-col gap-8 px-[4vw] text-center">
       <h1 class="text-2xl font-extrabold text-orange-400">#{tag.data.title}</h1>
@@ -47,6 +56,8 @@ posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
           ))
         }
       </div>
+
+      <MarkdownLink href={markdownUrl} />
     </Container>
 
     <div class="py-14">

--- a/src/pages/tag/[id].md.ts
+++ b/src/pages/tag/[id].md.ts
@@ -2,7 +2,8 @@ export const prerender = true
 
 import { type CollectionEntry, getCollection } from 'astro:content'
 import type { APIContext, GetStaticPaths } from 'astro'
-import { tagToMarkdown } from '@/lib/to-markdown'
+import { websiteUrl } from '@/lib/content'
+import { markdownResponse, tagToMarkdown } from '@/lib/to-markdown'
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const tags = await getCollection('tags')
@@ -17,7 +18,5 @@ export async function GET({ props, params }: APIContext) {
   )
   posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
 
-  return new Response(tagToMarkdown(tag, posts), {
-    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
-  })
+  return markdownResponse(tagToMarkdown(tag, posts), `${websiteUrl}/tag/${tag.id}`)
 }


### PR DESCRIPTION
## Summary
- Enrich markdown exports with YAML frontmatter, absolute links/images, attribution, and `X-Robots-Tag: noindex` so agents get clean text without SEO duplication
- Add `/llms-full.txt`, expand `/llms.txt` with topics + attribution, and expose markdown via `<link rel="alternate">` plus a “View as Markdown” link
- Add JSON-LD (`Person`, `WebSite`, `Blog`, `BlogPosting`, `CollectionPage`, `AboutPage`, `ContactPage`) across home, posts, tags, and static pages
- Edge Worker content negotiation: `Accept: text/markdown` returns the `.md` sibling at the HTML URL, with `Vary: Accept` and `Link: rel=alternate` on HTML responses (`run_worker_first`)

## Test plan
- [ ] Open `/llms.txt` and confirm Topics, Full content, and attribution sections
- [ ] Open `/llms-full.txt` and confirm posts/pages are concatenated
- [ ] Open a post HTML page and verify `application/ld+json`, `rel="alternate" type="text/markdown"`, and “View as Markdown”
- [ ] Open `/{slug}.md` and confirm YAML frontmatter, absolute image URLs, and noindex headers in response
- [ ] Confirm sitemap no longer lists `.md` / `llms*.txt` URLs
- [ ] Spot-check About/Press/Contact/Newsletter/Tag pages for JSON-LD + markdown link
- [ ] `curl -sI https://yagiz.co/about` → `Link: </about.md>; rel="alternate"; type="text/markdown"` and `Vary: Accept`
- [ ] `curl -sI -H 'Accept: text/markdown' https://yagiz.co/about` → `Content-Type: text/markdown`
- [ ] `curl -sI -H 'Accept: application/pdf' https://yagiz.co/about` → `406`