### PR TITLE
Add Accept markdown negotiation and Link headers

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,4 +1,3 @@
-import { readdirSync, readFileSync } from 'node:fs'
 import cloudflare from '@astrojs/cloudflare'
 import { unified } from '@astrojs/markdown-remark'
 import mdx from '@astrojs/mdx'
@@ -13,34 +12,8 @@ import rehypeSlug from 'rehype-slug'
 import remarkGfm from 'remark-gfm'
 import { websiteUrl } from './src/lib/content.ts'
 
-function listSlugs(dir: string): string[] {
-  return readdirSync(dir)
-    .filter((f) => !f.startsWith('_'))
-    .map((f) => f.replace(/\.mdx?$/, ''))
-}
-
-function publishedBlogSlugs(): string[] {
-  const dir = './src/content/blog'
-  return readdirSync(dir)
-    .filter((f) => !f.startsWith('_'))
-    .filter((f) => readFileSync(`${dir}/${f}`, 'utf-8').includes('status: published'))
-    .map((f) => f.replace(/\.mdx?$/, ''))
-}
-
-const markdownPages: string[] = [
-  `${websiteUrl}/index.md`,
-  ...publishedBlogSlugs().map((slug) => `${websiteUrl}/${slug}.md`),
-  ...listSlugs('./src/content/pages').map((slug) => `${websiteUrl}/${slug}.md`),
-  ...listSlugs('./src/content/tags').map((slug) => `${websiteUrl}/tag/${slug}.md`),
-]
-
 function isMarkdownOrLlmsAsset(page: string): boolean {
-  return (
-    page.endsWith('.md') ||
-    page.endsWith('/llms.txt') ||
-    page.endsWith('/llms-full.txt') ||
-    markdownPages.includes(page)
-  )
+  return page.endsWith('.md') || page.endsWith('/llms.txt') || page.endsWith('/llms-full.txt')
 }
 
 // https://astro.build/config

--- a/src/lib/accept.ts
+++ b/src/lib/accept.ts
@@ -1,0 +1,113 @@
+type AcceptEntry = { type: string; q: number; specificity: number }
+
+function parseAccept(header: string): AcceptEntry[] {
+  return header
+    .split(',')
+    .map((raw) => {
+      const parts = raw
+        .trim()
+        .split(';')
+        .map((s) => s.trim())
+      const type = parts[0]?.toLowerCase()
+      if (!type) return null
+
+      let q = 1
+      for (const param of parts.slice(1)) {
+        const [name, value] = param.split('=').map((s) => s.trim())
+        if (name === 'q') {
+          const parsed = Number(value)
+          if (!Number.isNaN(parsed)) q = Math.max(0, Math.min(1, parsed))
+        }
+      }
+
+      const specificity = type === '*/*' ? 0 : type.endsWith('/*') ? 1 : 2
+      return { type, q, specificity }
+    })
+    .filter((entry): entry is AcceptEntry => entry !== null)
+}
+
+function matches(entry: AcceptEntry, candidate: string): boolean {
+  if (entry.type === '*/*') return true
+  if (entry.type.endsWith('/*')) return candidate.startsWith(entry.type.slice(0, -1))
+  return entry.type === candidate
+}
+
+/**
+ * RFC 9110 Accept negotiation for a fixed set of produced types.
+ * Returns null when every candidate is explicitly rejected (q=0).
+ */
+export function preferredType(header: string | null, produces: string[]): string | null {
+  if (!header) return produces[0] ?? null
+
+  const entries = parseAccept(header)
+  if (entries.length === 0) return produces[0] ?? null
+
+  let bestType: string | null = null
+  let bestQ = -1
+  let bestPosition = Number.POSITIVE_INFINITY
+
+  for (const candidate of produces) {
+    let matched: AcceptEntry | null = null
+    let matchedPosition = Number.POSITIVE_INFINITY
+
+    for (let idx = 0; idx < entries.length; idx++) {
+      const entry = entries[idx]
+      if (!matches(entry, candidate)) continue
+      if (
+        matched === null ||
+        entry.specificity > matched.specificity ||
+        (entry.specificity === matched.specificity && idx < matchedPosition)
+      ) {
+        matched = entry
+        matchedPosition = idx
+      }
+    }
+
+    if (matched === null || matched.q <= 0) continue
+
+    if (matched.q > bestQ || (matched.q === bestQ && matchedPosition < bestPosition)) {
+      bestQ = matched.q
+      bestPosition = matchedPosition
+      bestType = candidate
+    }
+  }
+
+  return bestType
+}
+
+export function appendVaryAccept(headers: Headers): void {
+  const existing = headers.get('vary')
+  if (!existing) {
+    headers.set('Vary', 'Accept')
+    return
+  }
+  const tokens = existing.split(',').map((s) => s.trim().toLowerCase())
+  if (!tokens.includes('accept')) {
+    headers.set('Vary', `${existing}, Accept`)
+  }
+}
+
+export function appendLink(headers: Headers, value: string): void {
+  const existing = headers.get('link')
+  headers.set('Link', existing ? `${existing}, ${value}` : value)
+}
+
+/** Map an HTML pathname to this site's `.md` sibling (`/about` → `/about.md`). */
+export function markdownPath(pathname: string): string {
+  const clean = pathname.replace(/\/+$/, '') || '/'
+  if (clean === '/') return '/index.md'
+  return `${clean}.md`
+}
+
+const STATIC_EXT =
+  /\.(?:css|js|mjs|map|png|jpe?g|webp|gif|svg|avif|ico|woff2?|ttf|otf|eot|xml|txt|json|pdf|mp4|webm|mp3|wav|ogg|zip|md)$/i
+
+/** Paths that should skip HTML↔markdown negotiation. */
+export function shouldSkipNegotiation(pathname: string): boolean {
+  return (
+    pathname.startsWith('/api/') ||
+    pathname.startsWith('/_astro/') ||
+    pathname.startsWith('/cdn-cgi/') ||
+    STATIC_EXT.test(pathname)
+  )
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -92,7 +92,7 @@ export function blogPostingJsonLd(
       websiteJsonLd(),
       {
         '@type': 'BlogPosting',
-        '@id': url,
+        '@id': `${url}#blogposting`,
         mainEntityOfPage: {
           '@type': 'WebPage',
           '@id': url,

--- a/src/lib/to-markdown.ts
+++ b/src/lib/to-markdown.ts
@@ -13,8 +13,12 @@ const ATTRIBUTION = [
 ].join('\n')
 
 function escapeYaml(value: string): string {
-  if (/[:#{}[\],&*?|>!%@`]/.test(value) || value.includes('\n') || value.includes('"')) {
-    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  if (/[:#{}[\],&*?|>!%@`]/.test(value) || /[\n\r"]/.test(value) || value.includes('\\')) {
+    return `"${value
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"')
+      .replace(/\r/g, '\\r')
+      .replace(/\n/g, '\\n')}"`
   }
   return value
 }

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -50,6 +50,7 @@ export const GET: APIRoute = async () => {
     '## Full content',
     '',
     `- [Complete markdown dump](${websiteUrl}/llms-full.txt): Every published post and key page concatenated for single-fetch ingestion`,
+    '- HTML pages also negotiate `Accept: text/markdown` and advertise markdown via HTTP `Link: rel=alternate`',
     '',
     '## Optional',
     '',

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,80 @@
+import { handle } from '@astrojs/cloudflare/handler'
+import {
+  appendLink,
+  appendVaryAccept,
+  markdownPath,
+  preferredType,
+  shouldSkipNegotiation,
+} from './lib/accept'
+
+function notAcceptable(message: string): Response {
+  const response = new Response(message, {
+    status: 406,
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  })
+  appendVaryAccept(response.headers)
+  return response
+}
+
+function withHeaders(response: Response, mutate: (headers: Headers) => void): Response {
+  const headers = new Headers(response.headers)
+  mutate(headers)
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+async function assetsFetch(env: Env, request: Request, pathname: string): Promise<Response> {
+  const url = new URL(request.url)
+  url.pathname = pathname
+  return env.ASSETS.fetch(new Request(url.toString(), request))
+}
+
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    const url = new URL(request.url)
+
+    if (shouldSkipNegotiation(url.pathname)) {
+      return handle(request, env, ctx)
+    }
+
+    const accept = request.headers.get('accept')
+    const chosen = preferredType(accept, ['text/html', 'text/markdown'])
+
+    if (chosen === null && accept) {
+      return notAcceptable('Not Acceptable\n\nAvailable: text/html, text/markdown\n')
+    }
+
+    const mdPath = markdownPath(url.pathname)
+
+    if (chosen === 'text/markdown') {
+      const mdResponse = await assetsFetch(env, request, mdPath)
+      if (mdResponse.status === 200) {
+        return withHeaders(mdResponse, (headers) => {
+          headers.set('Content-Type', 'text/markdown; charset=utf-8')
+          appendVaryAccept(headers)
+          appendLink(
+            headers,
+            `<${url.pathname === '/' ? '/' : url.pathname.replace(/\/+$/, '') || '/'}>; rel="canonical"`,
+          )
+        })
+      }
+
+      if (!preferredType(accept, ['text/html'])) {
+        return notAcceptable(
+          'Not Acceptable\n\nMarkdown sibling missing and HTML is not acceptable.\n',
+        )
+      }
+    }
+
+    const response = await handle(request, env, ctx)
+    return withHeaders(response, (headers) => {
+      appendVaryAccept(headers)
+      if (headers.get('content-type')?.includes('text/html')) {
+        appendLink(headers, `<${mdPath}>; rel="alternate"; type="text/markdown"`)
+      }
+    })
+  },
+} satisfies ExportedHandler<Env>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,8 @@ compatibility_date = "2026-03-21"
 compatibility_flags = [ "nodejs_compat" ]
 send_metrics = false
 preview_urls = true
-main = "@astrojs/cloudflare/entrypoints/server"
+# Custom worker wraps Astro's handler for Accept negotiation + Link headers.
+main = "./src/worker.ts"
 
 [placement]
 mode = "smart"
@@ -21,6 +22,8 @@ database_id = "33ad2d37-f48c-4033-86fd-81c7ade04178"
 binding = "ASSETS"
 directory = "./dist"
 not_found_handling = "404-page"
+# Run the Worker before asset short-circuit so Accept negotiation can run on static HTML.
+run_worker_first = true
 
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary
- Custom Cloudflare Worker (`src/worker.ts`) with `run_worker_first` so static HTML still goes through edge logic
- `Accept: text/markdown` serves the existing `.md` sibling at the HTML URL (`Vary: Accept`)
- HTML responses get `Link: </path.md>; rel="alternate"; type="text/markdown"`
- Addresses Bugbot findings from #209: JSON-LD `@id` collision, YAML newline escaping, dead sitemap helpers

Follow-up to #209 (merged before negotiation + these fixes landed).

## Test plan
- [ ] `curl -sI https://yagiz.co/about` → `Link: </about.md>; rel="alternate"; type="text/markdown"` and `Vary: Accept`
- [ ] `curl -sI -H 'Accept: text/markdown' https://yagiz.co/about` → `Content-Type: text/markdown` and markdown body
- [ ] `curl -sI -H 'Accept: text/markdown' https://yagiz.co/state-of-url-parsing-2025` → markdown
- [ ] `curl -sI -H 'Accept: application/pdf' https://yagiz.co/about` → `406`
- [ ] Browser load of `/about` still returns normal HTML
- [ ] Post page JSON-LD: BlogPosting `@id` ends with `#blogposting`, WebPage `@id` is the canonical URL
- [ ] Sitemap still excludes `.md` / `llms*.txt`