### PR TITLE
Add blog post: Eliminating branches in C++ loops

### DIFF
--- a/src/content/blog/eliminating-branches-in-cpp-loops.mdx
+++ b/src/content/blog/eliminating-branches-in-cpp-loops.mdx
@@ -1,23 +1,29 @@
 ---
 title: 'Eliminating branches in C++ loops'
 description: >-
-  How to turn a validating for-loop into branchless code with bitwise
-  operations, a 256-byte lookup table, SWAR, and ARM NEON — the same
-  techniques we use in Ada.
+  A for loop that returns false from a branch and true at the end is easy
+  to read, but the branch can be expensive. In this post I show how to
+  remove it with bitwise operations, a 256-byte table, SWAR, and NEON.
 date: '2026-08-22'
 tag: performance
 status: published
 ---
 
-Hot loops in parsers, tokenizers, and validators almost always look the same.
-You walk a string, test each byte, and bail out as soon as something is
-wrong. That shape is easy to read. On a modern CPU it is often the wrong
-default, because the expensive part is not the comparison — it is the
-branch that depends on it.
+Writing efficient C++ can be quite challenging when you are working on
+hot loops in parsers, tokenizers, and validators. A very common pattern
+is a for loop that checks each character, returns false as soon as
+something is wrong, and returns true when the function ends. This is
+easy to read, but on a modern CPU it is often the wrong default. The
+expensive part is usually not the comparison itself. It is the branch
+that depends on it.
 
-This is the loop I want to talk about. It is the same pattern we keep
-hitting in [Ada][ada] when we classify URL characters: *is this entire
-input ASCII lowercase?*
+In this blog post, I want to walk through this pattern and show how we
+can eliminate the branching. We will start with bitwise operations, then
+use a precomputed lookup table, then do the same work with SWAR
+routines when SIMD is not available, and finally do it with ARM NEON.
+These are the same techniques we use in [Ada][ada] when we classify URL
+characters. The running example is simple: is this entire input ASCII
+lowercase?
 
 ```cpp title="The obvious validating loop"
 bool is_ascii_lowercase(std::string_view input) {
@@ -30,42 +36,46 @@ bool is_ascii_lowercase(std::string_view input) {
 }
 ```
 
-If any byte falls outside `a-z`, we return `false`. If the loop finishes,
-we return `true`. That early `return` *is* the branch. The rest of this
-post is about deleting it, then making the predicate itself cheaper, then
-doing eight or sixteen bytes of the same work at once.
+If any byte falls outside `a-z`, we return `false`. If the loop
+finishes, we return `true`. That early `return` is the branch we want
+to get rid of. The rest of this post is about deleting it, making the
+check itself cheaper, and then doing eight or sixteen bytes of the same
+work at once.
+
+One important detail before we start: always cast the byte to
+`unsigned char` before you classify it. A plain `char` may be signed,
+and a signed value above 127 can become a negative index or break the
+range check.
 
 ## Why the branch is expensive
 
-A compare on a register is cheap. A compare that steers the instruction
-stream is not. The CPU guesses which side of `if (c < 'a' || c > 'z')`
-will run, fetches that path, and pays a pipeline flush when it guessed
-wrong.
+A compare on a register is cheap. A compare that changes which
+instructions run next is not. The CPU guesses which side of
+`if (c < 'a' || c > 'z')` will run, fetches that path, and pays a
+pipeline flush when it guessed wrong.
 
-That cost is data-dependent:
+This cost depends on the data:
 
-- If almost every input is valid, the predictor learns *fall through* and
-  the naive loop is fine.
-- If invalid bytes appear at random offsets — or if valid and invalid
-  inputs are mixed — you pay a mispredict on every surprise.
+- If almost every input is valid, the predictor learns to fall through
+  and the naive loop is fine.
+- If invalid bytes appear at random offsets, or if valid and invalid
+  inputs are mixed, you pay a mispredict on every surprise.
 - An early `return` also blocks vectorization. The compiler cannot
   rewrite a loop that might exit on any iteration into a wide load.
 
-There is a second, quieter issue: `||` and `&&` short-circuit. The second
-compare only runs when the first one does not already decide the result.
-That is another branch, even before you `return`.
+There is a second issue that is easy to miss. `||` and `&&`
+short-circuit. The second compare only runs when the first one does not
+already decide the result. That is another branch, even before you
+`return`.
 
-Early exit is still the right call when the *common* case fails near the
-start of the string. The rest of this post assumes the opposite, which is
-the usual situation in a parser: you almost always scan the whole input.
-
-Always cast the byte to `unsigned char` before you classify it. A plain
-`char` may be signed, and a signed value above 127 turns into a negative
-index or a broken range check.
+Early exit is still the right call when the common case fails near the
+start of the string. The rest of this post assumes the opposite, which
+is the usual situation in a parser. You almost always scan the whole
+input.
 
 ## Accumulating the answer instead of returning early
 
-The first rewrite does not change what we compute. It changes *when* we
+The first rewrite does not change what we compute. It changes when we
 decide. Instead of leaving the function the moment a byte is bad, we
 keep a running flag and only look at it after the last iteration.
 
@@ -79,14 +89,15 @@ bool is_ascii_lowercase(std::string_view input) {
 }
 ```
 
-`&` is not `&&`. Bitwise AND always evaluates both sides, so there is no
-short-circuit branch. The loop body becomes *load, compare, compare,
-and, store* — a straight-line sequence the predictor does not have to
-guess. After the last byte we return the flag, which is `true` only if
-every iteration kept it set.
+`&` is not `&&`. Bitwise AND always evaluates both sides, so there is
+no short-circuit branch. The loop body becomes load, compare, compare,
+and, store. That is a straight-line sequence the predictor does not
+have to guess. After the last byte we return the flag, which is `true`
+only if every iteration kept it set.
 
-The dual form, which I prefer when I am hunting for problems rather than
-confirming they are absent, accumulates errors with OR:
+The other way to write this, which I prefer when I am looking for
+problems rather than confirming that everything is valid, is to
+accumulate errors with OR:
 
 ```cpp title="Branchless accumulation with bitwise OR"
 bool is_ascii_lowercase(std::string_view input) {
@@ -99,19 +110,19 @@ bool is_ascii_lowercase(std::string_view input) {
 }
 ```
 
-On x86 those compares compile to `setcc` (or a `cmp` plus an `adc`-style
-flag dance). That is a flag write, not a jump. The loop always runs to
-completion, which is exactly what you want when the happy path is *the
-whole string is fine*. It is also what the vectorizer wants to see.
+On x86 those compares compile to `setcc`, or a `cmp` plus something
+like `adc`. That is a flag write, not a jump. The loop always runs to
+completion, which is exactly what you want when the happy path is that
+the whole string is fine. It is also what the vectorizer wants to see.
 
-We still have two comparisons per byte. The next step is to collapse the
-predicate itself.
+We still have two comparisons per byte. The next step is to make the
+check itself cheaper.
 
 ## Bitwise operations: one compare, no short-circuit
 
-A byte is an ASCII lowercase letter if and only if it sits in the closed
-range `['a', 'z']`. Subtract `'a'` and that statement becomes *the result
-fits in 0..25*.
+A byte is an ASCII lowercase letter if and only if it sits in the
+closed range `['a', 'z']`. If we subtract `'a'`, that statement becomes
+"the result fits in 0 to 25".
 
 ```cpp title="Range check that wraps into a single unsigned compare"
 static inline bool is_lower(unsigned char c) {
@@ -119,7 +130,7 @@ static inline bool is_lower(unsigned char c) {
 }
 ```
 
-Walk through a few values:
+Let's walk through a few values:
 
 - `'a' - 'a'` is `0`, and `0 <= 25`.
 - `'m' - 'a'` is `12`, still in range.
@@ -128,12 +139,12 @@ Walk through a few values:
 - `'{' - 'a'` is `26`, just outside.
 - `'A' - 'a'` wraps well above 25, so uppercase is rejected.
 
-The wraparound is the trick. Bytes below `'a'` underflow modulo 256 and
-land in the high end of the `unsigned char` range, where they fail the
-same `<= 25` test as bytes above `'z'`. Two comparisons become one, and
-that one has no short-circuit.
+The wraparound is the trick. Bytes below `'a'` underflow modulo 256
+and land in the high end of the `unsigned char` range, where they fail
+the same `<= 25` test as bytes above `'z'`. Two comparisons become one,
+and that one has no short-circuit.
 
-Drop it into the accumulating loop:
+We can drop it into the accumulating loop:
 
 ```cpp title="Validating a string with a wraparound predicate"
 bool is_ascii_lowercase(std::string_view input) {
@@ -146,26 +157,27 @@ bool is_ascii_lowercase(std::string_view input) {
 }
 ```
 
-The body is now *subtract, compare, or*. No `if`. No `return` in the
-middle. No `||`. For a simple contiguous class like `a-z` this is
-usually as far as scalar code needs to go.
+The body is now subtract, compare, or. There is no `if`, no `return` in
+the middle, and no `||`. For a simple contiguous class like `a-z`, this
+is usually as far as scalar code needs to go.
 
-The wraparound test only works for a single closed interval. *Is this a
-hex digit? An unreserved URL character? A forbidden host character?*
-Those classes are unions of ranges and punctuations. Bitwise arithmetic
-gets ugly there. A table does not.
+The wraparound test only works for a single closed interval. If you
+want to know whether a character is a hex digit, an unreserved URL
+character, or a forbidden host character, those classes are unions of
+ranges and punctuation. Bitwise arithmetic gets ugly there. A table
+does not.
 
 ## A 256-byte lookup table
 
-You will sometimes hear *a table of size 255*. The last valid index of
-an 8-bit value is 255, but the length of the array is **256**. Byte
-values run from `0x00` through `0xFF` inclusive. A table of 255 entries
-leaves `0xFF` unmapped and invites an off-by-one the first time a
-non-ASCII byte shows up.
+You will sometimes hear people say "a table of size 255". The last
+valid index of an 8-bit value is 255, but the length of the array is
+**256**. Byte values run from `0x00` through `0xFF` inclusive. A table
+of 255 entries leaves `0xFF` unmapped and invites an off-by-one the
+first time a non-ASCII byte shows up.
 
-For ASCII classification that 256-byte table is the whole universe. Every
-input is a valid index, so the predicate cannot branch on the character
-itself. It can only load.
+For ASCII classification, that 256-byte table covers every possible
+input. Every byte is a valid index, so the check cannot branch on the
+character itself. It can only load.
 
 ```cpp title="Build a 256-entry lowercase table at compile time"
 consteval std::array<uint8_t, 256> make_lowercase_table() {
@@ -180,9 +192,9 @@ constexpr auto kIsLower = make_lowercase_table();
 ```
 
 `table{}` zero-initializes every slot. The loop turns on only `'a'`
-through `'z'`. Everything else — uppercase, digits, punctuation, bytes
-above 127 — stays `0`. The table is 256 bytes, which is four cache
-lines. It stays hot if this function is actually on the hot path.
+through `'z'`. Uppercase, digits, punctuation, and bytes above 127 stay
+`0`. The table is 256 bytes, which is four cache lines. It stays hot if
+this function is actually on the hot path.
 
 ```cpp title="Classify each byte with a load instead of a compare"
 bool is_ascii_lowercase(std::string_view input) {
@@ -196,10 +208,10 @@ bool is_ascii_lowercase(std::string_view input) {
 
 There is no `if (c >= 'a' && c <= 'z')`. There is a load from
 `kIsLower[c]` and an AND. The branch predictor has nothing to do. The
-same skeleton handles predicates that would be miserable as arithmetic.
+same skeleton handles checks that would be miserable as arithmetic.
 
-A hex-digit table is the example I reach for after lowercase, because
-hex is two ranges plus a gap:
+A hex-digit table is a good next example, because hex is two ranges
+plus a gap:
 
 ```cpp title="Hex digits are a messy range and a clean table"
 consteval std::array<uint8_t, 256> make_hex_table() {
@@ -223,34 +235,35 @@ bool is_ascii_hex(std::string_view input) {
 
 The scalar version of that check is
 `(c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')`.
-Six comparisons and a tree of short-circuit branches, or one load.
+That is six comparisons and a tree of short-circuit branches, or one
+load.
 
-This is how Ada classifies URL characters. Host, path, and percent-encoding
-rules are not a single interval. They are a pile of *allowed* and
-*forbidden* bytes. A 256-byte table per class is cheaper than explaining
-those rules to the branch predictor, and it is cheap enough that we keep
-one table per class rather than packing bits until the code is
-unreadable.
+This is how Ada classifies URL characters. Host, path, and
+percent-encoding rules are not a single interval. They are a pile of
+allowed and forbidden bytes. A 256-byte table per class is cheaper than
+explaining those rules to the branch predictor, and it is cheap enough
+that we keep one table per class rather than packing bits until the
+code is unreadable.
 
-Two caveats, both real:
+There are two caveats:
 
-- The table must be `unsigned char`-indexed. A signed `char` of `0xFF`
-  becomes `-1` and walks off the front of the array.
-- A table only wins if it stays in cache. 256 bytes is easy. A table per
-  call that you rebuild at runtime is not a table, it is a tax.
+- The table must be indexed with `unsigned char`. A signed `char` of
+  `0xFF` becomes `-1` and walks off the front of the array.
+- A table only wins if it stays in cache. 256 bytes is easy. Rebuilding
+  a table on every call is not a table. It is extra work.
 
-We are still doing one load per byte. The next two sections do eight and
-sixteen bytes per iteration.
+We are still doing one load per byte. The next two sections do eight
+and sixteen bytes per iteration.
 
 ## SWAR when SIMD is not available
 
-SWAR means *SIMD within a register*. You treat a `uint64_t` as eight
-packed bytes and use ordinary integer arithmetic — add, subtract, and,
-and not — to run the same test on all eight lanes at once. There is no
+SWAR means SIMD within a register. You treat a `uint64_t` as eight
+packed bytes and use ordinary integer arithmetic (add, subtract, and,
+and not) to run the same test on all eight lanes at once. There is no
 `#include <arm_neon.h>`, no AVX, and no runtime dispatch. The code is
 portable C++.
 
-The building block is *splat*: repeat a byte eight times so it lines up
+The building block is splat: repeat a byte eight times so it lines up
 with every lane.
 
 ```cpp title="Broadcast one byte across a 64-bit word"
@@ -263,8 +276,8 @@ constexpr uint64_t splat(uint8_t x) {
 ```
 
 `splat('a')` is `0x6161616161616161`. `kHigh` is a mask of the top bit
-of every byte. That high bit is our per-lane boolean: `0x80` means *this
-byte failed*, `0x00` means it did not.
+of every byte. That high bit is our per-lane boolean. `0x80` means this
+byte failed. `0x00` means it did not.
 
 Two tests from [Bit Twiddling Hacks][bithacks] tell us whether any lane
 is below or above a constant. They look like magic, so here is the
@@ -285,12 +298,12 @@ constexpr uint64_t bytes_greater_than(uint64_t x, uint8_t n) {
 ```
 
 `bytes_less_than` subtracts `n` from each byte. A lane that was already
-below `n` underflows and the `& ~x & kHigh` filter keeps only those
-underflows. `bytes_greater_than` adds `127 - n`. A lane above `n` crosses
-127 and lights the high bit; the `| x` term also catches bytes that
-already had their high bit set.
+below `n` underflows, and the `& ~x & kHigh` filter keeps only those
+underflows. `bytes_greater_than` adds `127 - n`. A lane above `n`
+crosses 127 and lights the high bit. The `| x` term also catches bytes
+that already had their high bit set.
 
-For ASCII input those additions and subtractions do not carry into the
+For ASCII input, those additions and subtractions do not carry into the
 next lane in a way that breaks the test, because every byte is below
 128. So we reject non-ASCII first, then apply both bounds:
 
@@ -303,15 +316,15 @@ bool eight_bytes_are_lowercase(uint64_t word) {
 }
 ```
 
-If `word` is `hhhhhzzz` (`h` is `'h'`, `z` is `'z'`), every lane sits in
-`['a', 'z']` and the three masks are zero. If one lane is `'A'` or `'{'`
-or `0xC3`, the corresponding high bit in the OR is set and the function
-returns `false`.
+If `word` is eight lowercase letters, every lane sits in `['a', 'z']`
+and the three masks are zero. If one lane is `'A'` or `'{'` or `0xC3`,
+the corresponding high bit in the OR is set and the function returns
+`false`.
 
-The string-level version loads eight bytes at a time with `memcpy` —
-that is the portable way to avoid alignment and strict-aliasing
-problems — ORs the failure masks into an accumulator, and finishes the
-tail with the scalar wraparound test.
+The string-level version loads eight bytes at a time with `memcpy`.
+That is the portable way to avoid alignment and strict-aliasing
+problems. It ORs the failure masks into an accumulator, and finishes
+the leftover bytes with the scalar wraparound test.
 
 ```cpp title="SWAR lowercase scan with a scalar tail"
 bool is_ascii_lowercase(std::string_view input) {
@@ -341,8 +354,8 @@ bool is_ascii_lowercase(std::string_view input) {
 The inner loop never branches on a character value. It always consumes
 eight bytes, always updates `bad`, and always continues. That is the
 same OR-accumulation idea as the scalar version, applied to a whole
-word. The leftover `n < 8` bytes are not worth the SWAR setup; the
-wraparound predicate is enough.
+word. The leftover `n < 8` bytes are not worth the SWAR setup. The
+wraparound check is enough.
 
 SWAR is the right tool when you do not have SIMD, when you do not want
 a runtime ISA dispatch, or when the leftover after a SIMD main loop is
@@ -354,7 +367,7 @@ real compare instructions.
 
 [ARM NEON][neon] gives you 128-bit vectors. One load brings in sixteen
 bytes. One compare produces sixteen lanes of `0xFF` or `0x00`. One OR
-accumulates failures. There is no SWAR carry dance, because the
+accumulates failures. There is no SWAR carry trick here, because the
 hardware already knows the lanes are independent.
 
 ```cpp title="NEON lowercase scan, 16 bytes per iteration"
@@ -389,28 +402,30 @@ bool is_ascii_lowercase(std::string_view input) {
 }
 ```
 
-What each intrinsic is doing:
+Here is what each intrinsic is doing:
 
 - `vdupq_n_u8('a')` is the NEON splat. Every lane holds `'a'`.
-- `vld1q_u8` loads 16 consecutive bytes. No `memcpy` dance; the
-  instruction accepts unaligned addresses.
+- `vld1q_u8` loads 16 consecutive bytes. You do not need `memcpy`
+  here. The instruction accepts unaligned addresses.
 - `vcgeq_u8` / `vcleq_u8` compare every lane against `'a'` and `'z'`.
-  A passing lane becomes `0xFF`, a failing lane becomes `0x00`.
+  A passing lane becomes `0xFF`. A failing lane becomes `0x00`.
 - `vandq_u8` of those two masks is the closed interval `['a', 'z']`.
 - `vmvnq_u8` flips it, so errors are `0xFF`.
 - `vorrq_u8` into `errors` is the same OR-accumulation as the scalar
   and SWAR loops.
-- `vmaxvq_u8` (AArch64) horizontally reduces the vector: if any lane
-  is non-zero, some byte was out of range.
+- `vmaxvq_u8` (AArch64) reduces the vector. If any lane is non-zero,
+  some byte was out of range.
 
-The tail is scalar on purpose. Sixteen-and-up is where NEON pays for
-the load. The leftover 0–15 bytes are cheaper as the wraparound test.
+The tail is scalar on purpose. Sixteen bytes and up is where NEON pays
+for the load. The leftover 0 to 15 bytes are cheaper as the wraparound
+test.
 
-For a single interval, vector compares beat a table. For the messy
-classes — hex, URL unreserved, JSON string-safe — NEON can still do
-the table lookup, just not as a 256-byte gather. The usual trick,
-which [simdjson][simdjson] popularized and which we use in Ada, is to
-split each byte into nibbles and look those up in two 16-byte tables.
+For a single interval, vector compares beat a table. For messier
+classes such as hex, URL unreserved characters, or JSON string-safe
+bytes, NEON can still do the table lookup. It just cannot do it as a
+256-byte gather. The usual trick, which [simdjson][simdjson]
+popularized and which we use in Ada, is to split each byte into
+nibbles and look those up in two 16-byte tables.
 
 ```cpp title="Nibble lookup: a 256-byte class table in two 16-byte vectors"
 uint8x16_t classify(uint8x16_t input,
@@ -429,41 +444,40 @@ have said yes. You are back to the lookup-table section, except the
 table now lives in registers and you classify 16 bytes per call.
 
 On x86 the same ideas map to SSE/AVX (`_mm_cmpeq_epi8`,
-`_mm_shuffle_epi8`). The NEON names change; the loop shape does not.
+`_mm_shuffle_epi8`). The NEON names change. The loop shape does not.
 
 ## Which one should you use?
 
-Use the technique that matches the predicate and the length of the
-input. I treat them as a ladder, not as competing religions.
+Use the technique that matches the check and the length of the input.
 
 1. **Early `return false`** when invalid input is common and usually
    fails in the first few bytes. Do not be clever if the branch is
    highly predictable and the function is not on a profiled hot path.
 2. **Bitwise accumulation** when you already scan the whole string and
-   the predicate is a single interval. The wraparound test
+   the check is a single interval. The wraparound test
    (`unsigned char(c - 'a') <= 25`) is the whole optimization.
-3. **A 256-byte table** when the predicate is a union of ranges or a
-   grab-bag of punctuation. One load replaces a tree of compares. Size
-   it at 256, not 255.
+3. **A 256-byte table** when the check is a union of ranges or a mix
+   of punctuation. One load replaces a tree of compares. Size it at
+   256, not 255.
 4. **SWAR** when the strings are long enough that eight bytes at a
    time matter and you cannot, or do not want to, ship SIMD. It is
    also the portable fallback behind a SIMD main loop.
 5. **NEON** (or SSE/AVX) when you are on a machine that has it and the
-   input is tens of bytes or more. Compare instructions for intervals,
-   nibble tables for everything else.
+   input is tens of bytes or more. Use compare instructions for
+   intervals, and nibble tables for everything else.
 
-Compilers at `-O3` already turn some of the scalar loops into
-`cmov` / `setcc` or even auto-vectorize them. They will not invent a
-256-byte character class for you, and they will not write the SWAR
+Compilers at `-O3` already turn some of the scalar loops into `cmov`
+or `setcc`, and they can even auto-vectorize them. They will not invent
+a 256-byte character class for you, and they will not write the SWAR
 masks. Measure the version you are about to delete. If the naive loop
 is already off the profile, leave it alone.
 
-The running example in this post is *is this string ASCII lowercase?*
-because the predicate is small enough to see every transformation. The
-reason I care is the other predicates: hex, unreserved, forbidden host
-bytes, whitespace. Those are the loops that show up in a URL parser,
-and those are the loops where a branchy `for` with an early `return`
-quietly becomes the whole function.
+I used "is this string ASCII lowercase?" as the running example
+because the check is small enough to see every transformation. In
+practice, the checks I care about are the other ones: hex,
+unreserved, forbidden host bytes, whitespace. Those are the loops
+that show up in a URL parser, and they are often where a simple
+`for` loop with an early `return` becomes the bottleneck.
 
 [ada]: https://github.com/ada-url/ada
 [bithacks]: https://graphics.stanford.edu/~seander/bithacks.html#HasLessInWord

--- a/src/content/blog/eliminating-branches-in-cpp-loops.mdx
+++ b/src/content/blog/eliminating-branches-in-cpp-loops.mdx
@@ -168,8 +168,13 @@ through `'z'`. Everything else stays `0`. Each character is checked
 with a single load, plus an AND. This might compile down to a single
 lookup instruction.
 
-It takes a bit more effort, but the same skeleton handles checks that
-would be miserable as arithmetic. Hex is two ranges plus a gap:
+I am using lowercase here so the skeleton is easy to see. I would not
+ship a table for `a-z`. The wraparound test is already one subtract
+and one compare. A table replaces that with a load, and the load is
+slower. The table starts to win when the check is no longer a single
+interval.
+
+Hex is the example I actually use this for. Two ranges plus a gap:
 
 ```cpp title="Hex digits are a messy range and a clean table"
 static constexpr std::array<uint8_t, 256> kIsHex = []() {
@@ -208,10 +213,10 @@ Two caveats:
   lines. Rebuilding the table on every call is extra work, not a
   table.
 
-In [Daniel's escaping benchmark][escaping], the table-based approach
-is quite competitive (around 1.9 GB/s on GCC). LLVM can autovectorize
-the branchless loop well enough that it sometimes beats the table. In
-every case he measured, hand-written SIMD was at least twice as fast.
+I will come back to this with numbers. The short version is that a
+table is the right tool for hex or forbidden host bytes, and the
+wrong tool for `a-z`. A range is already one subtract and one
+compare. A table turns that into a load, and loads have latency.
 
 Can we do better?
 
@@ -346,7 +351,13 @@ one of the conventional functions. If the leftover is non-empty but
 the string was already at least 16 bytes, you can reload the last 16
 bytes of the input. That overlapping load avoids a scalar tail.
 
-```cpp title="NEON lowercase scan, 16 bytes per iteration"
+The first NEON version I wrote used two compares, an AND, and a NOT:
+`vcgeq` against `'a'`, `vcleq` against `'z'`. That works. It is also
+more work than we need. The wraparound test is faster here too.
+Unsigned subtract wraps the same way in every lane, so we get
+`c - 'a'` for 16 bytes at once, then one unsigned compare against 25.
+
+```cpp title="NEON wraparound scan, 16 bytes per iteration"
 #include <arm_neon.h>
 
 bool is_ascii_lowercase(std::string_view input) {
@@ -363,48 +374,115 @@ bool is_ascii_lowercase(std::string_view input) {
   size_t n = input.size();
   uint8x16_t errors = vdupq_n_u8(0);
   const uint8x16_t va = vdupq_n_u8('a');
-  const uint8x16_t vz = vdupq_n_u8('z');
+  const uint8x16_t limit = vdupq_n_u8(25);
 
   size_t i = 0;
   for (; i + 15 < n; i += 16) {
     const uint8x16_t v = vld1q_u8(p + i);
-    const uint8x16_t in_range = vandq_u8(vcgeq_u8(v, va), vcleq_u8(v, vz));
-    errors = vorrq_u8(errors, vmvnq_u8(in_range));
+    const uint8x16_t d = vsubq_u8(v, va);
+    errors = vorrq_u8(errors, vcgtq_u8(d, limit));
   }
   if (i < n) {
     const uint8x16_t v = vld1q_u8(p + n - 16);
-    const uint8x16_t in_range = vandq_u8(vcgeq_u8(v, va), vcleq_u8(v, vz));
-    errors = vorrq_u8(errors, vmvnq_u8(in_range));
+    const uint8x16_t d = vsubq_u8(v, va);
+    errors = vorrq_u8(errors, vcgtq_u8(d, limit));
   }
 
   return vmaxvq_u8(errors) == 0;
 }
 ```
 
+That is load, subtract, compare, OR. The two-bound version was load,
+compare, compare, AND, NOT, OR. Same answer, fewer instructions.
+
 Here is what each intrinsic is doing:
 
 - `vdupq_n_u8('a')` is the NEON splat. Every lane holds `'a'`.
 - `vld1q_u8` loads 16 consecutive bytes. The instruction accepts
   unaligned addresses, so you do not need `memcpy`.
-- `vcgeq_u8` / `vcleq_u8` compare every lane against `'a'` and `'z'`.
-  A passing lane becomes `0xFF`. A failing lane becomes `0x00`.
-- `vandq_u8` of those two masks is the closed interval `['a', 'z']`.
-- `vmvnq_u8` flips it, so errors are `0xFF`.
+- `vsubq_u8` subtracts `'a'` from every lane. Bytes below `'a'` wrap,
+  exactly like `unsigned char(c - 'a')`.
+- `vcgtq_u8` is an unsigned greater-than. A lane becomes `0xFF` when
+  that wrapped value is greater than 25.
 - `vorrq_u8` into `errors` is the same OR-accumulation as before.
 - `vmaxvq_u8` (AArch64) reduces the vector. If any lane is non-zero,
   some byte was out of range.
 
-The magic of SIMD is that it can do 16 comparisons at once. You can
-optimize the function further to reduce the number of instructions,
-but it already uses far fewer when processing blocks of 16 bytes than
-the conventional functions.
+If the leftover is non-empty but the string was already at least 16
+bytes, we reload the last 16 bytes. That overlapping load avoids a
+scalar tail. Duplicate bytes are fine: we only OR errors.
 
-For a single interval, vector compares beat a table. For messier
-classes, the 256-byte table fails: there is no 256-byte gather on
-NEON. The usual trick is [vectorized classification][neon-ids] (see
-Langdale and Lemire, [Parsing Gigabytes of JSON per Second][pgjson]).
-We use the same idea in Ada. Split each byte into two 4-bit nibbles
-and look those up in two 16-byte tables:
+On x64 the same wraparound is subtract plus saturating unsigned
+subtract. `_mm_subs_epu8(d, 25)` becomes zero when `d <= 25`, and
+non-zero otherwise. Signed SIMD compares (`_mm_cmplt_epi8`) are a
+trap for bytes above 127, because those bytes look negative. The
+wraparound path stays unsigned the whole way.
+
+```cpp title="AVX2 wraparound scan, 32 bytes per iteration"
+bool is_ascii_lowercase(std::string_view input) {
+  if (input.size() < 32) {
+    unsigned errors = 0;
+    for (unsigned char c : input) {
+      errors |= static_cast<unsigned>(
+          static_cast<unsigned char>(c - 'a') > 25);
+    }
+    return errors == 0;
+  }
+
+  const auto* p = reinterpret_cast<const uint8_t*>(input.data());
+  size_t n = input.size();
+  __m256i errors = _mm256_setzero_si256();
+  const __m256i va = _mm256_set1_epi8('a');
+  const __m256i limit = _mm256_set1_epi8(25);
+
+  size_t i = 0;
+  for (; i + 31 < n; i += 32) {
+    const __m256i v =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p + i));
+    const __m256i d = _mm256_sub_epi8(v, va);
+    errors = _mm256_or_si256(errors, _mm256_subs_epu8(d, limit));
+  }
+  if (i < n) {
+    const __m256i v =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p + n - 32));
+    const __m256i d = _mm256_sub_epi8(v, va);
+    errors = _mm256_or_si256(errors, _mm256_subs_epu8(d, limit));
+  }
+
+  return _mm256_testz_si256(errors, errors) != 0;
+}
+```
+
+I ran these on an Intel Xeon with GCC 13.3 (`-O3 -march=native`),
+scanning a 1 MiB all-lowercase buffer. The happy path is the
+interesting one: you almost always scan the whole string.
+
+| Approach | Throughput |
+| --- | ---: |
+| Branchy early `return` | 4.0 GB/s |
+| 256-byte table | 3.1 GB/s |
+| Wraparound (GCC autovectorized) | 14.2 GB/s |
+| SSE2 two-compare | 31.6 GB/s |
+| SWAR | 53.2 GB/s |
+| SSE2 wraparound | 56.0 GB/s |
+| AVX2 wraparound | 63.9 GB/s |
+
+The table loses to the naive loop. It is bound by load latency, which
+is the same thing Daniel saw when he compared a 256-byte identifier
+table to NEON. GCC already turns the scalar wraparound loop into
+SIMD, and that is 3.5 times the branchy version, but the hand-written
+SWAR and AVX2 paths still win by a lot.
+
+If the first bad byte is near the start, the branchy loop wins, and
+the GB/s number becomes meaningless because you barely touch the
+buffer. That is the only case where I would keep the early `return`.
+
+For messier classes, the 256-byte table fails in SIMD: there is no
+256-byte gather on NEON. The usual trick is [vectorized
+classification][neon-ids] (see Langdale and Lemire, [Parsing
+Gigabytes of JSON per Second][pgjson]). We use the same idea in Ada.
+Split each byte into two 4-bit nibbles and look those up in two
+16-byte tables:
 
 ```cpp title="Nibble lookup: a 256-byte class table in two 16-byte vectors"
 uint8x16_t classify(uint8x16_t input,
@@ -427,31 +505,38 @@ On x86 the same ideas map to SSE/AVX (`_mm_cmpeq_epi8`,
 
 ## Which one should you use?
 
-It can be tricky to pick. Results depend on your compiler, your
-processor, and your data. Use the technique that matches the check and
-the length of the input.
+It depends on the check and on the length of the input. For a single
+interval like `a-z`, the numbers above are the whole story.
 
 1. **Early `return false`** when invalid input is common and usually
-   fails in the first few bytes. Do not be clever if the branch is
-   highly predictable and the function is not on a profiled hot path.
-2. **Bitwise accumulation** when you already scan the whole string and
-   the check is a single interval. The wraparound test
-   (`unsigned char(c - 'a') <= 25`) is the whole optimization.
-   Compilers at `-O3` can turn this into `cmov` / `setcc`, and LLVM
-   in particular may autovectorize it.
-3. **A 256-byte table** when the check is a union of ranges or a mix
-   of punctuation. One load replaces a tree of compares. Size it at
-   256, not 255.
-4. **SWAR** when the strings are long enough that eight bytes at a
-   time matter and you cannot, or do not want to, ship SIMD. It is
-   also the portable fallback behind a SIMD main loop.
-5. **NEON** (or SSE/AVX) when you are on a machine that has it and the
-   input is tens of bytes or more. Use compare instructions for
-   intervals, and nibble tables for everything else.
+   fails in the first few bytes. That is the only case where the
+   obvious loop is the fast one.
+2. **Wraparound** (`unsigned char(c - 'a') <= 25`) for a single
+   interval. Write it as a branchless scalar loop first. GCC and
+   LLVM will often autovectorize it. If that is already off the
+   profile, stop.
+3. **SWAR or SIMD wraparound** when the strings are long and you
+   still see the scan in a profile. Prefer subtract-and-compare over
+   two bounds. AVX2 or NEON will beat a portable SWAR loop when you
+   have them. SWAR is the right fallback when you do not.
+4. **A 256-byte table** when the check is a union of ranges or a mix
+   of punctuation: hex, unreserved, forbidden host bytes. Size it at
+   256, not 255. Do not use a table for `a-z`. You are paying a load
+   for a subtract.
+5. **Nibble tables in NEON/SSSE3** when that messy class is also
+   the hot SIMD path. That is vectorized classification, the same
+   idea we use in Ada.
+
+You can still go further. Unrolling the NEON or AVX2 loop to 32 or
+64 bytes hides some of the reduction latency. If invalid input is
+common but not always at byte 0, check the accumulator every few
+vectors and return early. On newer ARM, SVE2 `match` / `nmatch` can
+replace a pile of equality tests for small character sets. I would
+not start there.
 
 Compilers will not invent a 256-byte character class for you, and they
 will not write the SWAR masks. Measure the version you are about to
-delete. If the naive loop is already off the profile, leave it alone.
+delete.
 
 I used "is this string ASCII lowercase?" as the running example
 because the check is small enough to see every transformation. In

--- a/src/content/blog/eliminating-branches-in-cpp-loops.mdx
+++ b/src/content/blog/eliminating-branches-in-cpp-loops.mdx
@@ -552,15 +552,19 @@ problem.
 ## A harder problem: is this valid UTF-16?
 
 Modern-day text in software can be expected to be Unicode. Unicode
-is stored in two formats: UTF-8 and UTF-16. Microsoft Windows uses
-UTF-16 for file names and registry keys. Java and JavaScript use
-it for strings.
+is stored in two formats: UTF-8 and UTF-16.
+
+UTF-16 is used by several platforms to represent Unicode
+characters. Microsoft Windows uses it for file names and registry
+keys. Java and JavaScript use it for strings.
 
 UTF-16 represents each character by one or two 16-bit code units.
 For characters in the Basic Multilingual Plane, which includes most
 commonly used characters from around the world, a single 16-bit
 unit suffices. For characters beyond this plane, UTF-16 uses a
-pair of 16-bit units known as a surrogate pair.
+pair of 16-bit units known as a surrogate pair. That is how it
+covers a bit more than a million code points while keeping most
+characters in 16 bits.
 
 Values making up surrogate pairs are either high surrogates
 (`U+D800` to `U+DBFF`) or low surrogates (`U+DC00` to `U+DFFF`). A
@@ -568,8 +572,10 @@ pair is always made of a high surrogate followed by a low
 surrogate. Otherwise, we have an error.
 
 [Daniel has a post][utf16-neon] on putting a replacement character
-wherever that rule breaks. [simdutf][simdutf] is the production
-version. I want the simpler question: is the input valid?
+(`U+FFFD`) wherever that rule breaks. [simdutf][simdutf] is the
+production version, and it is what V8 uses for
+`String.toWellFormed`. I only need the boolean: is this valid
+UTF-16?
 
 A basic C++ function might look as follows.
 
@@ -602,153 +608,198 @@ The function scans a buffer of `char16_t` values. If a high
 surrogate is followed by a low surrogate, we skip both. If a high
 surrogate is not followed by a low surrogate, or if a low
 surrogate appears without a preceding high surrogate, we return
-`false`. If the loop finishes, we return `true`. It is the same
-shape as the lowercase loop we started with. The function should
-be reasonably efficient.
+`false`. If the loop finishes, we return `true`. The function
+should be reasonably efficient.
 
-It is also a different problem. The predicate looks at the next
-unit. You have state. You cannot AND a per-unit flag and be done.
-A 256-byte table does not help much: the input is 16-bit, and a
-table of 65536 entries is 64 KiB.
+Most of our processors have instructions that process eight 16-bit
+words per register. Most mobile processors today are 64-bit ARM
+with NEON. And most UTF-16 text never leaves the BMP. I suspect
+that this is the typical case: there are relatively few surrogate
+pairs in most text.
 
-We can do better with the wraparound test. Adding `0x2800` to a
-high surrogate wraps it into `0x0000..0x03FF`. Adding `0x2400`
-does the same for a low surrogate. That is the same
-`unsigned(c - lo) <= hi - lo` trick, written as an add.
+If you do not have NEON, you can still ask whether four code units
+contain any surrogate at all. Mask each 16-bit lane of a
+`uint64_t` with `0xF800` and look for `0xD800`. No match means
+those four units are valid BMP text and you can skip the pairing.
+That is the same SWAR trick as the lowercase scan, just on 16-bit
+lanes.
 
-```cpp title="Wraparound tests for high and low surrogates"
-bool is_high_surrogate(char16_t c) {
-  return static_cast<uint16_t>(c + 0x2800) <= 0x03FF;
-}
+We can write a function targeting ARM NEON using intrinsic
+functions. These give us low-level access to NEON. There are
+comparable intrinsics for Intel/AMD, RISC-V, and so on.
 
-bool is_low_surrogate(char16_t c) {
-  return static_cast<uint16_t>(c + 0x2400) <= 0x03FF;
-}
-```
+The classification inside the loop is the wraparound test from
+earlier. Adding `0x2800` to a high surrogate wraps it into
+`0x0000` to `0x03FF`. Adding `0x2400` does the same for a low
+surrogate.
 
-You can also do it with a mask. All values from `0xD800` to
-`0xDFFF` have the top five bits set to `11011`. High vs low is the
-next two bits.
+```cpp title="NEON: validate eight code units at a time"
+bool is_valid_utf16_neon(std::u16string_view input) {
+  const char16_t* buffer = input.data();
+  const size_t length = input.size();
+  const size_t vec_size = 8;
+  size_t i = 0;
 
-```cpp title="Classify a code unit with a mask"
-bool is_surrogate(char16_t c) {
-  return (c & 0xF800) == 0xD800;
-}
+  if (length >= vec_size) {
+    uint16x8_t previous_high_surrogate_mask = vdupq_n_u16(0);
+    for (; i + vec_size <= length; i += vec_size) {
+      const uint16x8_t vec = vld1q_u16(
+          reinterpret_cast<const uint16_t*>(buffer + i));
 
-bool is_high_surrogate(char16_t c) {
-  return (c & 0xFC00) == 0xD800;
-}
+      const uint16x8_t low_surrogate_mask = vcleq_u16(
+          vaddq_u16(vec, vdupq_n_u16(0x2400)), vdupq_n_u16(0x03FF));
+      const uint16x8_t high_surrogate_mask = vcleq_u16(
+          vaddq_u16(vec, vdupq_n_u16(0x2800)), vdupq_n_u16(0x03FF));
 
-bool is_low_surrogate(char16_t c) {
-  return (c & 0xFC00) == 0xDC00;
-}
-```
+      const uint16x8_t offset_high_surrogate_mask = vextq_u16(
+          previous_high_surrogate_mask, high_surrogate_mask, 7);
+      const uint16x8_t offset_low_surrogate_mask =
+          (i + vec_size < length &&
+           is_low_surrogate(buffer[i + vec_size]))
+              ? vextq_u16(low_surrogate_mask, vdupq_n_u16(0xFFFF), 1)
+              : vextq_u16(low_surrogate_mask, vdupq_n_u16(0), 1);
 
-Can we do better? Most of our processors have instructions that
-process eight 16-bit words per register. And most UTF-16 text never
-leaves the BMP. I suspect that this is the typical case: there are
-relatively few surrogate pairs in most text. If a block has no
-word in `0xD800..0xDFFF`, the whole block is valid and we can skip
-the pairing.
+      const uint16x8_t low_not_preceded_by_high =
+          vbicq_u16(low_surrogate_mask, offset_high_surrogate_mask);
+      const uint16x8_t high_not_followed_by_low =
+          vbicq_u16(high_surrogate_mask, offset_low_surrogate_mask);
 
-SWAR can ask that question for four code units in a `uint64_t`.
-Mask each 16-bit lane with `0xF800`, XOR with `0xD800`, and look
-for a zero lane.
-
-```cpp title="Any surrogate in four UTF-16 code units?"
-constexpr uint64_t kSurrogateBits = 0xF800F800F800F800ULL;
-constexpr uint64_t kSurrogateWant = 0xD800D800D800D800ULL;
-constexpr uint64_t kLaneHigh = 0x8000800080008000ULL;
-constexpr uint64_t kLaneOne = 0x0001000100010001ULL;
-
-bool has_surrogate_word(uint64_t word) {
-  const uint64_t xor_lanes = (word & kSurrogateBits) ^ kSurrogateWant;
-  return ((xor_lanes - kLaneOne) & ~xor_lanes & kLaneHigh) != 0;
-}
-```
-
-If there is no surrogate, those four units are valid. If there is
-one, we fall back to the scalar function for that block. You can
-do even better if you assume that the input is almost always
-valid. I am going to leave the full skip-until-you-find-one loop
-as an exercise.
-
-When we do have to pair, ARM NEON can do it in chunks of eight
-code units. We build a high-surrogate mask and a low-surrogate
-mask, then shift them to check for valid pairs across vector
-boundaries. The last high-surrogate lane of the previous chunk
-has to come along. That carry is the whole difference from the
-lowercase scan.
-
-```cpp title="NEON: pair surrogates eight code units at a time"
-bool is_valid_utf16_block(uint16x8_t vec, bool& pending_high) {
-  const uint16x8_t high_surrogate_mask = vcleq_u16(
-      vaddq_u16(vec, vdupq_n_u16(0x2800)), vdupq_n_u16(0x03FF));
-  const uint16x8_t low_surrogate_mask = vcleq_u16(
-      vaddq_u16(vec, vdupq_n_u16(0x2400)), vdupq_n_u16(0x03FF));
-
-  if (pending_high && vgetq_lane_u16(low_surrogate_mask, 0) == 0) {
-    return false;
+      if (vmaxvq_u16(vorrq_u16(low_not_preceded_by_high,
+                               high_not_followed_by_low)) != 0) {
+        return false;
+      }
+      previous_high_surrogate_mask = high_surrogate_mask;
+    }
   }
 
-  const uint16x8_t previous_high = vdupq_n_u16(pending_high ? 0xFFFF : 0);
-  const uint16x8_t offset_high =
-      vextq_u16(previous_high, high_surrogate_mask, 7);
-  const uint16x8_t offset_low =
-      vextq_u16(low_surrogate_mask, vdupq_n_u16(0), 1);
+  if (i > 0 && is_high_surrogate(buffer[i - 1]) && i < length &&
+      is_low_surrogate(buffer[i])) {
+    ++i;
+  }
 
-  const uint16x8_t low_not_preceded_by_high =
-      vbicq_u16(low_surrogate_mask, offset_high);
-  uint16x8_t high_not_followed_by_low =
-      vbicq_u16(high_surrogate_mask, offset_low);
-  high_not_followed_by_low =
-      vsetq_lane_u16(0, high_not_followed_by_low, 7);
-
-  pending_high = vgetq_lane_u16(high_surrogate_mask, 7) != 0;
-  return vmaxvq_u16(vorrq_u16(low_not_preceded_by_high,
-                              high_not_followed_by_low)) == 0;
+  for (; i < length; ++i) {
+    if (is_high_surrogate(buffer[i])) {
+      if (i + 1 < length && is_low_surrogate(buffer[i + 1])) {
+        ++i;
+      } else {
+        return false;
+      }
+    } else if (is_low_surrogate(buffer[i])) {
+      return false;
+    }
+  }
+  return true;
 }
 ```
 
-`vextq_u16` shifts the masks so each lane is checked against its
-neighbor. `vbicq` is AND-NOT: a low with no high in front of it,
-or a high with no low after it. If the chunk ends on a high
-surrogate, we do not fail yet. We set `pending_high` and let the
-next chunk pair it. If `pending_high` is still set after the last
-chunk, the string ended on a lone high surrogate and we return
-`false`.
+This function uses NEON to validate UTF-16 in chunks of eight
+code units. For each chunk it loads the data, builds a high
+surrogate mask and a low surrogate mask, shifts those masks to
+check for valid pairs across vector boundaries, and returns
+`false` on a lone high or a lone low. After as many full chunks
+as we can, the remaining units go through the scalar function.
+If the last vector unit was a high surrogate and the first tail
+unit is its low partner, we skip that low so the scalar loop
+does not treat it as unmatched.
 
-The function should be reasonably efficient. Though I expect that
-it is possible to do much better.
+Though reasonably efficient, I expect that it is possible to do
+much better than this function.
 
 A reader of Daniel's post proposed a faster alternative that uses
-the fact that ARM NEON has interleaved loads. `vld2q_u8` puts the
-most significant bytes in one register and the least significant
-bytes in the other. The most significant bytes are sufficient to
-check for errors. You throw the low bytes away and classify 16
-code units from one 16-byte register. [The follow-up paper][utf16-paper]
-pushes that idea to 64-unit blocks.
+the fact that ARM NEON has interleaved loads. When we load the
+data, we put the most significant bytes in one register and the
+least significant bytes in the other. The most significant bytes
+are sufficient to check for errors, so we can check 32 bytes of
+input by validating just one 16-byte register.
 
-Daniel measured the correction version of this, not the boolean
-one, on an Apple M2 with LLVM 16. A 10 million space string, no
-surrogates, the easiest case and I suspect also the typical one:
+```cpp title="Faster NEON: classify 16 code units from the high bytes"
+bool is_valid_utf16_neon_v2(std::u16string_view input) {
+  const char16_t* buffer = input.data();
+  const size_t length = input.size();
+  const int high_vec = 1;
+  const size_t vec_size = 32;
+  size_t i = 0;
+
+  if (length * 2 >= vec_size) {
+    uint8x16_t previous_high_surrogate_mask = vdupq_n_u8(0);
+    const uint8_t* buffer8 =
+        reinterpret_cast<const uint8_t*>(buffer);
+    for (; i + vec_size < length * 2; i += vec_size) {
+      const uint8x16x2_t pair = vld2q_u8(buffer8 + i);
+      const uint8x16_t vec = vshrq_n_u8(pair.val[high_vec], 2);
+
+      const uint8x16_t low_surrogate_mask =
+          vceqq_u8(vec, vdupq_n_u8(0x37));
+      const uint8x16_t high_surrogate_mask =
+          vceqq_u8(vec, vdupq_n_u8(0x36));
+
+      const uint8x16_t offset_high_surrogate_mask = vextq_u8(
+          previous_high_surrogate_mask, high_surrogate_mask, 15);
+      const uint8_t next_char_type =
+          buffer8[i + vec_size + high_vec] >> 2;
+      const uint8x16_t offset_low_surrogate_mask = vextq_u8(
+          low_surrogate_mask,
+          vdupq_n_u8(next_char_type == 0x37 ? 0xFF : 0), 1);
+
+      const uint8x16_t low_not_preceded_by_high =
+          vbicq_u8(low_surrogate_mask, offset_high_surrogate_mask);
+      const uint8x16_t high_not_followed_by_low =
+          vbicq_u8(high_surrogate_mask, offset_low_surrogate_mask);
+
+      if (vmaxvq_u8(vorrq_u8(low_not_preceded_by_high,
+                             high_not_followed_by_low)) != 0) {
+        return false;
+      }
+      previous_high_surrogate_mask = high_surrogate_mask;
+    }
+    i >>= 1;
+  }
+
+  if (i > 0 && is_high_surrogate(buffer[i - 1]) && i < length &&
+      is_low_surrogate(buffer[i])) {
+    ++i;
+  }
+
+  for (; i < length; ++i) {
+    const uint16_t surrogate_type =
+        static_cast<uint16_t>(buffer[i]) >> 10;
+    if (surrogate_type == 0x36) {
+      if (i + 1 < length && is_low_surrogate(buffer[i + 1])) {
+        ++i;
+      } else {
+        return false;
+      }
+    } else if (surrogate_type == 0x37) {
+      return false;
+    }
+  }
+  return true;
+}
+```
+
+`0x36` is a high surrogate's top six bits (`0xD800 >> 10`). `0x37`
+is a low surrogate (`0xDC00 >> 10`). [The follow-up paper][utf16-paper]
+pushes the same idea to 64-unit blocks.
+
+You can do even better if you assume that the input rarely
+contains invalid characters, or rarely contains surrogates at
+all. I am going to leave that as an exercise for the reader.
+
+To benchmark these functions, Daniel used a single string made of
+10 million space characters. It is the easiest case: no
+replacement and no surrogate pairs. I suspect that it also
+represents a typical case. Using LLVM 16 and an Apple M2, he got:
 
 | Approach | Throughput |
 | --- | ---: |
 | Regular C | 1.7 GB/s |
-| NEON, eight units | 5.5 GB/s |
-| Fast NEON (`vld2q_u8`) | 13 GB/s |
+| NEON | 5.5 GB/s |
+| Fast NEON | 13 GB/s |
 
 So the fast ARM NEON code is about 8 times faster than the
-conventional code. Validation is the same pairing with a
-`return false` instead of a store of `U+FFFD`.
-
-The ladder did not change. You still want fewer branches. You
-still want a cheap test that accepts the common case without
-pairing. You still want SIMD when the strings are long. The new
-cost is one bit of state between blocks, because a pair is always
-made of a high surrogate followed by a low surrogate. Otherwise,
-we have an error.
+conventional code. He was measuring the correction version. The
+boolean one is the same pairing, with a `return false` instead of
+a store of `U+FFFD`.
 
 [ada]: https://github.com/ada-url/ada
 [lemire]: https://lemire.me

--- a/src/content/blog/eliminating-branches-in-cpp-loops.mdx
+++ b/src/content/blog/eliminating-branches-in-cpp-loops.mdx
@@ -1,0 +1,471 @@
+---
+title: 'Eliminating branches in C++ loops'
+description: >-
+  How to turn a validating for-loop into branchless code with bitwise
+  operations, a 256-byte lookup table, SWAR, and ARM NEON — the same
+  techniques we use in Ada.
+date: '2026-08-22'
+tag: performance
+status: published
+---
+
+Hot loops in parsers, tokenizers, and validators almost always look the same.
+You walk a string, test each byte, and bail out as soon as something is
+wrong. That shape is easy to read. On a modern CPU it is often the wrong
+default, because the expensive part is not the comparison — it is the
+branch that depends on it.
+
+This is the loop I want to talk about. It is the same pattern we keep
+hitting in [Ada][ada] when we classify URL characters: *is this entire
+input ASCII lowercase?*
+
+```cpp title="The obvious validating loop"
+bool is_ascii_lowercase(std::string_view input) {
+  for (unsigned char c : input) {
+    if (c < 'a' || c > 'z') {
+      return false;
+    }
+  }
+  return true;
+}
+```
+
+If any byte falls outside `a-z`, we return `false`. If the loop finishes,
+we return `true`. That early `return` *is* the branch. The rest of this
+post is about deleting it, then making the predicate itself cheaper, then
+doing eight or sixteen bytes of the same work at once.
+
+## Why the branch is expensive
+
+A compare on a register is cheap. A compare that steers the instruction
+stream is not. The CPU guesses which side of `if (c < 'a' || c > 'z')`
+will run, fetches that path, and pays a pipeline flush when it guessed
+wrong.
+
+That cost is data-dependent:
+
+- If almost every input is valid, the predictor learns *fall through* and
+  the naive loop is fine.
+- If invalid bytes appear at random offsets — or if valid and invalid
+  inputs are mixed — you pay a mispredict on every surprise.
+- An early `return` also blocks vectorization. The compiler cannot
+  rewrite a loop that might exit on any iteration into a wide load.
+
+There is a second, quieter issue: `||` and `&&` short-circuit. The second
+compare only runs when the first one does not already decide the result.
+That is another branch, even before you `return`.
+
+Early exit is still the right call when the *common* case fails near the
+start of the string. The rest of this post assumes the opposite, which is
+the usual situation in a parser: you almost always scan the whole input.
+
+Always cast the byte to `unsigned char` before you classify it. A plain
+`char` may be signed, and a signed value above 127 turns into a negative
+index or a broken range check.
+
+## Accumulating the answer instead of returning early
+
+The first rewrite does not change what we compute. It changes *when* we
+decide. Instead of leaving the function the moment a byte is bad, we
+keep a running flag and only look at it after the last iteration.
+
+```cpp title="Branchless accumulation with bitwise AND"
+bool is_ascii_lowercase(std::string_view input) {
+  bool ok = true;
+  for (unsigned char c : input) {
+    ok &= (c >= 'a') & (c <= 'z');
+  }
+  return ok;
+}
+```
+
+`&` is not `&&`. Bitwise AND always evaluates both sides, so there is no
+short-circuit branch. The loop body becomes *load, compare, compare,
+and, store* — a straight-line sequence the predictor does not have to
+guess. After the last byte we return the flag, which is `true` only if
+every iteration kept it set.
+
+The dual form, which I prefer when I am hunting for problems rather than
+confirming they are absent, accumulates errors with OR:
+
+```cpp title="Branchless accumulation with bitwise OR"
+bool is_ascii_lowercase(std::string_view input) {
+  unsigned errors = 0;
+  for (unsigned char c : input) {
+    errors |= static_cast<unsigned>(c < 'a');
+    errors |= static_cast<unsigned>(c > 'z');
+  }
+  return errors == 0;
+}
+```
+
+On x86 those compares compile to `setcc` (or a `cmp` plus an `adc`-style
+flag dance). That is a flag write, not a jump. The loop always runs to
+completion, which is exactly what you want when the happy path is *the
+whole string is fine*. It is also what the vectorizer wants to see.
+
+We still have two comparisons per byte. The next step is to collapse the
+predicate itself.
+
+## Bitwise operations: one compare, no short-circuit
+
+A byte is an ASCII lowercase letter if and only if it sits in the closed
+range `['a', 'z']`. Subtract `'a'` and that statement becomes *the result
+fits in 0..25*.
+
+```cpp title="Range check that wraps into a single unsigned compare"
+static inline bool is_lower(unsigned char c) {
+  return static_cast<unsigned char>(c - 'a') <= 25;
+}
+```
+
+Walk through a few values:
+
+- `'a' - 'a'` is `0`, and `0 <= 25`.
+- `'m' - 'a'` is `12`, still in range.
+- `'z' - 'a'` is `25`, still in range.
+- `` '`' - 'a' `` wraps to `255`, and `255 <= 25` is false.
+- `'{' - 'a'` is `26`, just outside.
+- `'A' - 'a'` wraps well above 25, so uppercase is rejected.
+
+The wraparound is the trick. Bytes below `'a'` underflow modulo 256 and
+land in the high end of the `unsigned char` range, where they fail the
+same `<= 25` test as bytes above `'z'`. Two comparisons become one, and
+that one has no short-circuit.
+
+Drop it into the accumulating loop:
+
+```cpp title="Validating a string with a wraparound predicate"
+bool is_ascii_lowercase(std::string_view input) {
+  unsigned errors = 0;
+  for (unsigned char c : input) {
+    errors |= static_cast<unsigned>(
+        static_cast<unsigned char>(c - 'a') > 25);
+  }
+  return errors == 0;
+}
+```
+
+The body is now *subtract, compare, or*. No `if`. No `return` in the
+middle. No `||`. For a simple contiguous class like `a-z` this is
+usually as far as scalar code needs to go.
+
+The wraparound test only works for a single closed interval. *Is this a
+hex digit? An unreserved URL character? A forbidden host character?*
+Those classes are unions of ranges and punctuations. Bitwise arithmetic
+gets ugly there. A table does not.
+
+## A 256-byte lookup table
+
+You will sometimes hear *a table of size 255*. The last valid index of
+an 8-bit value is 255, but the length of the array is **256**. Byte
+values run from `0x00` through `0xFF` inclusive. A table of 255 entries
+leaves `0xFF` unmapped and invites an off-by-one the first time a
+non-ASCII byte shows up.
+
+For ASCII classification that 256-byte table is the whole universe. Every
+input is a valid index, so the predicate cannot branch on the character
+itself. It can only load.
+
+```cpp title="Build a 256-entry lowercase table at compile time"
+consteval std::array<uint8_t, 256> make_lowercase_table() {
+  std::array<uint8_t, 256> table{};
+  for (unsigned c = 'a'; c <= 'z'; ++c) {
+    table[c] = 1;
+  }
+  return table;
+}
+
+constexpr auto kIsLower = make_lowercase_table();
+```
+
+`table{}` zero-initializes every slot. The loop turns on only `'a'`
+through `'z'`. Everything else — uppercase, digits, punctuation, bytes
+above 127 — stays `0`. The table is 256 bytes, which is four cache
+lines. It stays hot if this function is actually on the hot path.
+
+```cpp title="Classify each byte with a load instead of a compare"
+bool is_ascii_lowercase(std::string_view input) {
+  uint8_t ok = 1;
+  for (unsigned char c : input) {
+    ok &= kIsLower[c];
+  }
+  return ok != 0;
+}
+```
+
+There is no `if (c >= 'a' && c <= 'z')`. There is a load from
+`kIsLower[c]` and an AND. The branch predictor has nothing to do. The
+same skeleton handles predicates that would be miserable as arithmetic.
+
+A hex-digit table is the example I reach for after lowercase, because
+hex is two ranges plus a gap:
+
+```cpp title="Hex digits are a messy range and a clean table"
+consteval std::array<uint8_t, 256> make_hex_table() {
+  std::array<uint8_t, 256> table{};
+  for (unsigned c = '0'; c <= '9'; ++c) table[c] = 1;
+  for (unsigned c = 'a'; c <= 'f'; ++c) table[c] = 1;
+  for (unsigned c = 'A'; c <= 'F'; ++c) table[c] = 1;
+  return table;
+}
+
+constexpr auto kIsHex = make_hex_table();
+
+bool is_ascii_hex(std::string_view input) {
+  uint8_t ok = 1;
+  for (unsigned char c : input) {
+    ok &= kIsHex[c];
+  }
+  return ok != 0;
+}
+```
+
+The scalar version of that check is
+`(c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')`.
+Six comparisons and a tree of short-circuit branches, or one load.
+
+This is how Ada classifies URL characters. Host, path, and percent-encoding
+rules are not a single interval. They are a pile of *allowed* and
+*forbidden* bytes. A 256-byte table per class is cheaper than explaining
+those rules to the branch predictor, and it is cheap enough that we keep
+one table per class rather than packing bits until the code is
+unreadable.
+
+Two caveats, both real:
+
+- The table must be `unsigned char`-indexed. A signed `char` of `0xFF`
+  becomes `-1` and walks off the front of the array.
+- A table only wins if it stays in cache. 256 bytes is easy. A table per
+  call that you rebuild at runtime is not a table, it is a tax.
+
+We are still doing one load per byte. The next two sections do eight and
+sixteen bytes per iteration.
+
+## SWAR when SIMD is not available
+
+SWAR means *SIMD within a register*. You treat a `uint64_t` as eight
+packed bytes and use ordinary integer arithmetic — add, subtract, and,
+and not — to run the same test on all eight lanes at once. There is no
+`#include <arm_neon.h>`, no AVX, and no runtime dispatch. The code is
+portable C++.
+
+The building block is *splat*: repeat a byte eight times so it lines up
+with every lane.
+
+```cpp title="Broadcast one byte across a 64-bit word"
+constexpr uint64_t kOnes = 0x0101010101010101ULL;
+constexpr uint64_t kHigh = 0x8080808080808080ULL;
+
+constexpr uint64_t splat(uint8_t x) {
+  return kOnes * x;
+}
+```
+
+`splat('a')` is `0x6161616161616161`. `kHigh` is a mask of the top bit
+of every byte. That high bit is our per-lane boolean: `0x80` means *this
+byte failed*, `0x00` means it did not.
+
+Two tests from [Bit Twiddling Hacks][bithacks] tell us whether any lane
+is below or above a constant. They look like magic, so here is the
+actual contract:
+
+```cpp title="Per-byte comparisons inside a uint64_t"
+// High bit set in each byte of x that is strictly less than n.
+// Requires n <= 128.
+constexpr uint64_t bytes_less_than(uint64_t x, uint8_t n) {
+  return (x - splat(n)) & ~x & kHigh;
+}
+
+// High bit set in each byte of x that is strictly greater than n.
+// Requires n < 128.
+constexpr uint64_t bytes_greater_than(uint64_t x, uint8_t n) {
+  return ((x + splat(127 - n)) | x) & kHigh;
+}
+```
+
+`bytes_less_than` subtracts `n` from each byte. A lane that was already
+below `n` underflows and the `& ~x & kHigh` filter keeps only those
+underflows. `bytes_greater_than` adds `127 - n`. A lane above `n` crosses
+127 and lights the high bit; the `| x` term also catches bytes that
+already had their high bit set.
+
+For ASCII input those additions and subtractions do not carry into the
+next lane in a way that breaks the test, because every byte is below
+128. So we reject non-ASCII first, then apply both bounds:
+
+```cpp title="Eight lowercase checks in one uint64_t"
+bool eight_bytes_are_lowercase(uint64_t word) {
+  const uint64_t non_ascii = word & kHigh;
+  const uint64_t too_small = bytes_less_than(word, 'a');
+  const uint64_t too_large = bytes_greater_than(word, 'z');
+  return (non_ascii | too_small | too_large) == 0;
+}
+```
+
+If `word` is `hhhhhzzz` (`h` is `'h'`, `z` is `'z'`), every lane sits in
+`['a', 'z']` and the three masks are zero. If one lane is `'A'` or `'{'`
+or `0xC3`, the corresponding high bit in the OR is set and the function
+returns `false`.
+
+The string-level version loads eight bytes at a time with `memcpy` —
+that is the portable way to avoid alignment and strict-aliasing
+problems — ORs the failure masks into an accumulator, and finishes the
+tail with the scalar wraparound test.
+
+```cpp title="SWAR lowercase scan with a scalar tail"
+bool is_ascii_lowercase(std::string_view input) {
+  const auto* p = reinterpret_cast<const unsigned char*>(input.data());
+  size_t n = input.size();
+  uint64_t bad = 0;
+
+  while (n >= 8) {
+    uint64_t word;
+    std::memcpy(&word, p, sizeof(word));
+    bad |= word & kHigh;
+    bad |= bytes_less_than(word, 'a');
+    bad |= bytes_greater_than(word, 'z');
+    p += 8;
+    n -= 8;
+  }
+
+  while (n--) {
+    bad |= static_cast<uint64_t>(
+        static_cast<unsigned char>(*p++ - 'a') > 25);
+  }
+
+  return bad == 0;
+}
+```
+
+The inner loop never branches on a character value. It always consumes
+eight bytes, always updates `bad`, and always continues. That is the
+same OR-accumulation idea as the scalar version, applied to a whole
+word. The leftover `n < 8` bytes are not worth the SWAR setup; the
+wraparound predicate is enough.
+
+SWAR is the right tool when you do not have SIMD, when you do not want
+a runtime ISA dispatch, or when the leftover after a SIMD main loop is
+still several words long. It is also a good way to understand the SIMD
+code, because NEON is the same algorithm with 16-byte registers and
+real compare instructions.
+
+## The same check with NEON
+
+[ARM NEON][neon] gives you 128-bit vectors. One load brings in sixteen
+bytes. One compare produces sixteen lanes of `0xFF` or `0x00`. One OR
+accumulates failures. There is no SWAR carry dance, because the
+hardware already knows the lanes are independent.
+
+```cpp title="NEON lowercase scan, 16 bytes per iteration"
+#include <arm_neon.h>
+
+bool is_ascii_lowercase(std::string_view input) {
+  const auto* p = reinterpret_cast<const uint8_t*>(input.data());
+  size_t n = input.size();
+
+  uint8x16_t errors = vdupq_n_u8(0);
+  const uint8x16_t va = vdupq_n_u8('a');
+  const uint8x16_t vz = vdupq_n_u8('z');
+
+  while (n >= 16) {
+    const uint8x16_t v = vld1q_u8(p);
+    const uint8x16_t in_range = vandq_u8(vcgeq_u8(v, va), vcleq_u8(v, vz));
+    errors = vorrq_u8(errors, vmvnq_u8(in_range));
+    p += 16;
+    n -= 16;
+  }
+
+  if (vmaxvq_u8(errors) != 0) {
+    return false;
+  }
+
+  while (n--) {
+    if (static_cast<unsigned char>(*p++ - 'a') > 25) {
+      return false;
+    }
+  }
+  return true;
+}
+```
+
+What each intrinsic is doing:
+
+- `vdupq_n_u8('a')` is the NEON splat. Every lane holds `'a'`.
+- `vld1q_u8` loads 16 consecutive bytes. No `memcpy` dance; the
+  instruction accepts unaligned addresses.
+- `vcgeq_u8` / `vcleq_u8` compare every lane against `'a'` and `'z'`.
+  A passing lane becomes `0xFF`, a failing lane becomes `0x00`.
+- `vandq_u8` of those two masks is the closed interval `['a', 'z']`.
+- `vmvnq_u8` flips it, so errors are `0xFF`.
+- `vorrq_u8` into `errors` is the same OR-accumulation as the scalar
+  and SWAR loops.
+- `vmaxvq_u8` (AArch64) horizontally reduces the vector: if any lane
+  is non-zero, some byte was out of range.
+
+The tail is scalar on purpose. Sixteen-and-up is where NEON pays for
+the load. The leftover 0–15 bytes are cheaper as the wraparound test.
+
+For a single interval, vector compares beat a table. For the messy
+classes — hex, URL unreserved, JSON string-safe — NEON can still do
+the table lookup, just not as a 256-byte gather. The usual trick,
+which [simdjson][simdjson] popularized and which we use in Ada, is to
+split each byte into nibbles and look those up in two 16-byte tables.
+
+```cpp title="Nibble lookup: a 256-byte class table in two 16-byte vectors"
+uint8x16_t classify(uint8x16_t input,
+                    uint8x16_t table_lo,
+                    uint8x16_t table_hi) {
+  const uint8x16_t lo = vandq_u8(input, vdupq_n_u8(0x0F));
+  const uint8x16_t hi = vshrq_n_u8(input, 4);
+  return vandq_u8(vqtbl1q_u8(table_lo, lo), vqtbl1q_u8(table_hi, hi));
+}
+```
+
+`vqtbl1q_u8` is a 16-entry table lookup done on all sixteen lanes at
+once. The low nibble picks a row, the high nibble picks a row, and the
+AND is 1 only when both halves of the original 256-entry table would
+have said yes. You are back to the lookup-table section, except the
+table now lives in registers and you classify 16 bytes per call.
+
+On x86 the same ideas map to SSE/AVX (`_mm_cmpeq_epi8`,
+`_mm_shuffle_epi8`). The NEON names change; the loop shape does not.
+
+## Which one should you use?
+
+Use the technique that matches the predicate and the length of the
+input. I treat them as a ladder, not as competing religions.
+
+1. **Early `return false`** when invalid input is common and usually
+   fails in the first few bytes. Do not be clever if the branch is
+   highly predictable and the function is not on a profiled hot path.
+2. **Bitwise accumulation** when you already scan the whole string and
+   the predicate is a single interval. The wraparound test
+   (`unsigned char(c - 'a') <= 25`) is the whole optimization.
+3. **A 256-byte table** when the predicate is a union of ranges or a
+   grab-bag of punctuation. One load replaces a tree of compares. Size
+   it at 256, not 255.
+4. **SWAR** when the strings are long enough that eight bytes at a
+   time matter and you cannot, or do not want to, ship SIMD. It is
+   also the portable fallback behind a SIMD main loop.
+5. **NEON** (or SSE/AVX) when you are on a machine that has it and the
+   input is tens of bytes or more. Compare instructions for intervals,
+   nibble tables for everything else.
+
+Compilers at `-O3` already turn some of the scalar loops into
+`cmov` / `setcc` or even auto-vectorize them. They will not invent a
+256-byte character class for you, and they will not write the SWAR
+masks. Measure the version you are about to delete. If the naive loop
+is already off the profile, leave it alone.
+
+The running example in this post is *is this string ASCII lowercase?*
+because the predicate is small enough to see every transformation. The
+reason I care is the other predicates: hex, unreserved, forbidden host
+bytes, whitespace. Those are the loops that show up in a URL parser,
+and those are the loops where a branchy `for` with an early `return`
+quietly becomes the whole function.
+
+[ada]: https://github.com/ada-url/ada
+[bithacks]: https://graphics.stanford.edu/~seander/bithacks.html#HasLessInWord
+[neon]: https://developer.arm.com/architectures/instruction-sets/intrinsics/
+[simdjson]: https://github.com/simdjson/simdjson

--- a/src/content/blog/eliminating-branches-in-cpp-loops.mdx
+++ b/src/content/blog/eliminating-branches-in-cpp-loops.mdx
@@ -546,94 +546,114 @@ unreserved, forbidden host bytes, whitespace. Those are the loops
 that show up in a URL parser, and they are often where a simple
 `for` loop with an early `return` becomes the bottleneck.
 
-The same tools also apply when the check is no longer independent
-per byte. UTF-16 is the example I reach for.
+So far every byte stood on its own. Suppose you want a harder
+problem.
 
 ## A harder problem: is this valid UTF-16?
 
-ASCII lowercase is a per-byte question. Each character stands on
-its own. UTF-16 does not work that way.
+Modern-day text in software can be expected to be Unicode. Unicode
+is stored in two formats: UTF-8 and UTF-16. Microsoft Windows uses
+UTF-16 for file names and registry keys. Java and JavaScript use
+it for strings.
 
-A UTF-16 string is a sequence of 16-bit code units. Most of Unicode
-fits in one unit. That is the Basic Multilingual Plane: everything
-from `U+0000` to `U+D7FF` and from `U+E000` to `U+FFFF`. Characters
-above `U+FFFF` use two units, a surrogate pair. The first unit is a
-high surrogate (`U+D800` to `U+DBFF`). The second is a low surrogate
-(`U+DC00` to `U+DFFF`). A high surrogate must be followed by a low
-surrogate. A low surrogate must be preceded by a high surrogate.
-Anything else is invalid.
+UTF-16 represents each character by one or two 16-bit code units.
+For characters in the Basic Multilingual Plane, which includes most
+commonly used characters from around the world, a single 16-bit
+unit suffices. For characters beyond this plane, UTF-16 uses a
+pair of 16-bit units known as a surrogate pair.
 
-Windows, Java, and JavaScript all store strings this way. [Daniel
-has a post][utf16-neon] on fixing broken UTF-16 in place with NEON.
-[simdutf][simdutf] is the production version of the same idea. The
-question I want is simpler: is this input valid UTF-16?
+Values making up surrogate pairs are either high surrogates
+(`U+D800` to `U+DBFF`) or low surrogates (`U+DC00` to `U+DFFF`). A
+pair is always made of a high surrogate followed by a low
+surrogate. Otherwise, we have an error.
 
-A reasonable function looks a lot like the loop we started with.
-We return `false` from a branch, and `true` at the end.
+[Daniel has a post][utf16-neon] on putting a replacement character
+wherever that rule breaks. [simdutf][simdutf] is the production
+version. I want the simpler question: is the input valid?
 
-```cpp title="The obvious UTF-16 validator"
-static inline bool is_high_surrogate(char16_t c) {
-  return static_cast<uint16_t>(c - 0xD800) <= 0x03FF;
+A basic C++ function might look as follows.
+
+```cpp title="A basic UTF-16 validator"
+bool is_high_surrogate(char16_t c) {
+  return (c >= 0xD800 && c <= 0xDBFF);
 }
 
-static inline bool is_low_surrogate(char16_t c) {
-  return static_cast<uint16_t>(c - 0xDC00) <= 0x03FF;
+bool is_low_surrogate(char16_t c) {
+  return (c >= 0xDC00 && c <= 0xDFFF);
 }
 
 bool is_valid_utf16(std::u16string_view input) {
-  for (size_t i = 0; i < input.size();) {
-    const char16_t u = input[i];
-    if (static_cast<uint16_t>(u - 0xD800) > 0x07FF) {
-      ++i;
-      continue;
-    }
-    if (!is_high_surrogate(u) || i + 1 >= input.size() ||
-        !is_low_surrogate(input[i + 1])) {
+  for (size_t i = 0; i < input.size(); ++i) {
+    if (is_high_surrogate(input[i])) {
+      if (i + 1 < input.size() && is_low_surrogate(input[i + 1])) {
+        ++i;
+      } else {
+        return false;
+      }
+    } else if (is_low_surrogate(input[i])) {
       return false;
     }
-    i += 2;
   }
   return true;
 }
 ```
 
-The wraparound test is back. `(u - 0xD800) > 0x07FF` means "not a
-surrogate at all". `(u - 0xD800) <= 0x03FF` means high.
-`(u - 0xDC00) <= 0x03FF` means low. You can also do it with a mask,
-which I like better here:
+The function scans a buffer of `char16_t` values. If a high
+surrogate is followed by a low surrogate, we skip both. If a high
+surrogate is not followed by a low surrogate, or if a low
+surrogate appears without a preceding high surrogate, we return
+`false`. If the loop finishes, we return `true`. It is the same
+shape as the lowercase loop we started with. The function should
+be reasonably efficient.
+
+It is also a different problem. The predicate looks at the next
+unit. You have state. You cannot AND a per-unit flag and be done.
+A 256-byte table does not help much: the input is 16-bit, and a
+table of 65536 entries is 64 KiB.
+
+We can do better with the wraparound test. Adding `0x2800` to a
+high surrogate wraps it into `0x0000..0x03FF`. Adding `0x2400`
+does the same for a low surrogate. That is the same
+`unsigned(c - lo) <= hi - lo` trick, written as an add.
+
+```cpp title="Wraparound tests for high and low surrogates"
+bool is_high_surrogate(char16_t c) {
+  return static_cast<uint16_t>(c + 0x2800) <= 0x03FF;
+}
+
+bool is_low_surrogate(char16_t c) {
+  return static_cast<uint16_t>(c + 0x2400) <= 0x03FF;
+}
+```
+
+You can also do it with a mask. All values from `0xD800` to
+`0xDFFF` have the top five bits set to `11011`. High vs low is the
+next two bits.
 
 ```cpp title="Classify a code unit with a mask"
-static inline bool is_surrogate(char16_t c) {
+bool is_surrogate(char16_t c) {
   return (c & 0xF800) == 0xD800;
 }
 
-static inline bool is_high_surrogate(char16_t c) {
+bool is_high_surrogate(char16_t c) {
   return (c & 0xFC00) == 0xD800;
 }
 
-static inline bool is_low_surrogate(char16_t c) {
+bool is_low_surrogate(char16_t c) {
   return (c & 0xFC00) == 0xDC00;
 }
 ```
 
-`0xD800` to `0xDFFF` all have the top five bits `11011`. That is
-what `c & 0xF800` tests. High vs low is the next two bits.
+Can we do better? Most of our processors have instructions that
+process eight 16-bit words per register. And most UTF-16 text never
+leaves the BMP. I suspect that this is the typical case: there are
+relatively few surrogate pairs in most text. If a block has no
+word in `0xD800..0xDFFF`, the whole block is valid and we can skip
+the pairing.
 
-This is already harder than lowercase. The predicate looks at the
-next unit. You have state. A lone high at the end of the string is
-an error. A lone low in the middle is an error. Two highs in a row
-are an error. You cannot AND a per-unit flag and be done.
-
-A 256-byte table does not help much either. The input is 16-bit.
-A table of 65536 entries is 64 KiB. That is no longer four cache
-lines.
-
-What does help is the same observation we used for lowercase: most
-input is fine. Most UTF-16 text never leaves the BMP. There are no
-surrogates at all. If a block has no word in `0xD800..0xDFFF`, the
-whole block is valid and we can skip it.
-
-SWAR can do that for four code units in a `uint64_t`:
+SWAR can ask that question for four code units in a `uint64_t`.
+Mask each 16-bit lane with `0xF800`, XOR with `0xD800`, and look
+for a zero lane.
 
 ```cpp title="Any surrogate in four UTF-16 code units?"
 constexpr uint64_t kSurrogateBits = 0xF800F800F800F800ULL;
@@ -647,73 +667,88 @@ bool has_surrogate_word(uint64_t word) {
 }
 ```
 
-Mask each 16-bit lane with `0xF800`, XOR with `0xD800`, and look
-for a zero lane. If there is none, those four units are valid. If
-there is one, we fall back to the scalar pairing loop for that
-block. That is the same OR-accumulation idea, except the cheap
-path is "no surrogates" and the expensive path is the state
-machine.
+If there is no surrogate, those four units are valid. If there is
+one, we fall back to the scalar function for that block. You can
+do even better if you assume that the input is almost always
+valid. I am going to leave the full skip-until-you-find-one loop
+as an exercise.
 
-On NEON you load eight code units and do the pairing in the
-vector. The trick is to build a high-surrogate mask and a
-low-surrogate mask, then shift one of them so each lane is
-checked against its neighbor. The last high-surrogate bit of the
-previous block has to come along. That carry is the whole
-difference from the lowercase scan.
+When we do have to pair, ARM NEON can do it in chunks of eight
+code units. We build a high-surrogate mask and a low-surrogate
+mask, then shift them to check for valid pairs across vector
+boundaries. The last high-surrogate lane of the previous chunk
+has to come along. That carry is the whole difference from the
+lowercase scan.
 
-```cpp title="NEON UTF-16 block: pair surrogates across lanes"
+```cpp title="NEON: pair surrogates eight code units at a time"
 bool is_valid_utf16_block(uint16x8_t vec, bool& pending_high) {
-  const uint16x8_t high = vceqq_u16(
-      vandq_u16(vec, vdupq_n_u16(0xFC00)), vdupq_n_u16(0xD800));
-  const uint16x8_t low = vceqq_u16(
-      vandq_u16(vec, vdupq_n_u16(0xFC00)), vdupq_n_u16(0xDC00));
+  const uint16x8_t high_surrogate_mask = vcleq_u16(
+      vaddq_u16(vec, vdupq_n_u16(0x2800)), vdupq_n_u16(0x03FF));
+  const uint16x8_t low_surrogate_mask = vcleq_u16(
+      vaddq_u16(vec, vdupq_n_u16(0x2400)), vdupq_n_u16(0x03FF));
 
-  if (pending_high && vgetq_lane_u16(low, 0) == 0) {
+  if (pending_high && vgetq_lane_u16(low_surrogate_mask, 0) == 0) {
     return false;
   }
 
-  const uint16x8_t prev = vdupq_n_u16(pending_high ? 0xFFFF : 0);
-  const uint16x8_t high_before = vextq_u16(prev, high, 7);
-  const uint16x8_t low_after = vextq_u16(low, vdupq_n_u16(0), 1);
+  const uint16x8_t previous_high = vdupq_n_u16(pending_high ? 0xFFFF : 0);
+  const uint16x8_t offset_high =
+      vextq_u16(previous_high, high_surrogate_mask, 7);
+  const uint16x8_t offset_low =
+      vextq_u16(low_surrogate_mask, vdupq_n_u16(0), 1);
 
-  const uint16x8_t lone_low = vbicq_u16(low, high_before);
-  uint16x8_t lone_high = vbicq_u16(high, low_after);
-  lone_high = vsetq_lane_u16(0, lone_high, 7);
+  const uint16x8_t low_not_preceded_by_high =
+      vbicq_u16(low_surrogate_mask, offset_high);
+  uint16x8_t high_not_followed_by_low =
+      vbicq_u16(high_surrogate_mask, offset_low);
+  high_not_followed_by_low =
+      vsetq_lane_u16(0, high_not_followed_by_low, 7);
 
-  pending_high = vgetq_lane_u16(high, 7) != 0;
-  return vmaxvq_u16(vorrq_u16(lone_low, lone_high)) == 0;
+  pending_high = vgetq_lane_u16(high_surrogate_mask, 7) != 0;
+  return vmaxvq_u16(vorrq_u16(low_not_preceded_by_high,
+                              high_not_followed_by_low)) == 0;
 }
 ```
 
-`vextq_u16(prev, high, 7)` takes the last lane of the previous
-high-surrogate mask and puts it in front of the current one. Each
-low lane is then checked against the high that came before it.
-`vbicq` is AND-NOT: a low with no high in front of it, or a high
-with no low after it.
-
-The last lane is the carry. If this block ends on a high
+`vextq_u16` shifts the masks so each lane is checked against its
+neighbor. `vbicq` is AND-NOT: a low with no high in front of it,
+or a high with no low after it. If the chunk ends on a high
 surrogate, we do not fail yet. We set `pending_high` and let the
-next block pair it. If the next block starts with anything other
-than a low surrogate, that is an error. If `pending_high` is still
-set after the last block, the string ended on a lone high
-surrogate and we return `false`. That is the one piece of state
-the lowercase scan never needed.
+next chunk pair it. If `pending_high` is still set after the last
+chunk, the string ended on a lone high surrogate and we return
+`false`.
 
-You can go further the way a reader did on Daniel's post. NEON
-can deinterleave with `vld2q_u8`: even bytes in one register, odd
-bytes in the other. For little-endian UTF-16, the high byte of
-each code unit is enough to tell high surrogate, low surrogate,
-or neither. You throw away the low bytes and classify 16 units
-from one 16-byte register. [The follow-up paper][utf16-paper]
+The function should be reasonably efficient. Though I expect that
+it is possible to do much better.
+
+A reader of Daniel's post proposed a faster alternative that uses
+the fact that ARM NEON has interleaved loads. `vld2q_u8` puts the
+most significant bytes in one register and the least significant
+bytes in the other. The most significant bytes are sufficient to
+check for errors. You throw the low bytes away and classify 16
+code units from one 16-byte register. [The follow-up paper][utf16-paper]
 pushes that idea to 64-unit blocks.
 
-The point is not to paste a production validator into a blog
-post. [simdutf][simdutf] already has one. The point is that the
-ladder did not change. You still want fewer branches. You still
-want a cheap test that rejects the common case without pairing.
-You still want SIMD when the strings are long. The new cost is
-the carry: one bit of state between blocks, because UTF-16 is a
-tiny state machine and lowercase is not.
+Daniel measured the correction version of this, not the boolean
+one, on an Apple M2 with LLVM 16. A 10 million space string, no
+surrogates, the easiest case and I suspect also the typical one:
+
+| Approach | Throughput |
+| --- | ---: |
+| Regular C | 1.7 GB/s |
+| NEON, eight units | 5.5 GB/s |
+| Fast NEON (`vld2q_u8`) | 13 GB/s |
+
+So the fast ARM NEON code is about 8 times faster than the
+conventional code. Validation is the same pairing with a
+`return false` instead of a store of `U+FFFD`.
+
+The ladder did not change. You still want fewer branches. You
+still want a cheap test that accepts the common case without
+pairing. You still want SIMD when the strings are long. The new
+cost is one bit of state between blocks, because a pair is always
+made of a high surrogate followed by a low surrogate. Otherwise,
+we have an error.
 
 [ada]: https://github.com/ada-url/ada
 [lemire]: https://lemire.me

--- a/src/content/blog/eliminating-branches-in-cpp-loops.mdx
+++ b/src/content/blog/eliminating-branches-in-cpp-loops.mdx
@@ -9,21 +9,12 @@ tag: performance
 status: published
 ---
 
-Writing efficient C++ can be quite challenging when you are working on
-hot loops in parsers, tokenizers, and validators. A very common pattern
-is a for loop that checks each character, returns false as soon as
-something is wrong, and returns true when the function ends. This is
-easy to read, but on a modern CPU it is often the wrong default. The
-expensive part is usually not the comparison itself. It is the branch
-that depends on it.
+Suppose you want to check whether a string is made entirely of ASCII
+lowercase letters. It is a common check in parsers. In [Ada][ada] we do
+this kind of classification constantly for URL characters: is this a
+hex digit, an unreserved character, a forbidden host code point?
 
-In this blog post, I want to walk through this pattern and show how we
-can eliminate the branching. We will start with bitwise operations, then
-use a precomputed lookup table, then do the same work with SWAR
-routines when SIMD is not available, and finally do it with ARM NEON.
-These are the same techniques we use in [Ada][ada] when we classify URL
-characters. The running example is simple: is this entire input ASCII
-lowercase?
+A reasonable function might look as follows.
 
 ```cpp title="The obvious validating loop"
 bool is_ascii_lowercase(std::string_view input) {
@@ -37,49 +28,34 @@ bool is_ascii_lowercase(std::string_view input) {
 ```
 
 If any byte falls outside `a-z`, we return `false`. If the loop
-finishes, we return `true`. That early `return` is the branch we want
-to get rid of. The rest of this post is about deleting it, making the
-check itself cheaper, and then doing eight or sixteen bytes of the same
-work at once.
+finishes, we return `true`. Importantly, this function exits as soon as
+a bad character is found.
 
-One important detail before we start: always cast the byte to
-`unsigned char` before you classify it. A plain `char` may be signed,
-and a signed value above 127 can become a negative index or break the
-range check.
+If we expect that almost every input is valid, that early `return` can
+be expensive. The CPU guesses which side of the `if` will run. When it
+guesses wrong, you pay a pipeline flush. `||` and `&&` make it worse
+because they short-circuit: the second compare is itself a branch.
 
-## Why the branch is expensive
+[Daniel Lemire][lemire] has a [post][escaping] on a similar problem:
+checking whether a JSON string needs escaping. The structure is the
+same. A loop, a branch, `return true` at the end. The rest of this
+post follows the same ladder he uses there: scan the whole string,
+replace the compare with a table, then do eight or sixteen bytes at
+once.
 
-A compare on a register is cheap. A compare that changes which
-instructions run next is not. The CPU guesses which side of
-`if (c < 'a' || c > 'z')` will run, fetches that path, and pays a
-pipeline flush when it guessed wrong.
+Always cast the byte to `unsigned char` (or `uint8_t`) before you
+classify it. A plain `char` may be signed, and a signed value above
+127 can become a negative index or break the range check.
 
-This cost depends on the data:
+## Scan the whole string
 
-- If almost every input is valid, the predictor learns to fall through
-  and the naive loop is fine.
-- If invalid bytes appear at random offsets, or if valid and invalid
-  inputs are mixed, you pay a mispredict on every surprise.
-- An early `return` also blocks vectorization. The compiler cannot
-  rewrite a loop that might exit on any iteration into a wide load.
+If we expect that no bad character will be found, we can always scan
+the whole input. That lets the compiler try other optimizations. In
+particular, it is more likely to autovectorize the loop: to compile it
+using SIMD instructions on its own. Daniel calls this version
+branchless, because it does not branch out of the loop.
 
-There is a second issue that is easy to miss. `||` and `&&`
-short-circuit. The second compare only runs when the first one does not
-already decide the result. That is another branch, even before you
-`return`.
-
-Early exit is still the right call when the common case fails near the
-start of the string. The rest of this post assumes the opposite, which
-is the usual situation in a parser. You almost always scan the whole
-input.
-
-## Accumulating the answer instead of returning early
-
-The first rewrite does not change what we compute. It changes when we
-decide. Instead of leaving the function the moment a byte is bad, we
-keep a running flag and only look at it after the last iteration.
-
-```cpp title="Branchless accumulation with bitwise AND"
+```cpp title="Branchless accumulation"
 bool is_ascii_lowercase(std::string_view input) {
   bool ok = true;
   for (unsigned char c : input) {
@@ -90,16 +66,13 @@ bool is_ascii_lowercase(std::string_view input) {
 ```
 
 `&` is not `&&`. Bitwise AND always evaluates both sides, so there is
-no short-circuit branch. The loop body becomes load, compare, compare,
-and, store. That is a straight-line sequence the predictor does not
-have to guess. After the last byte we return the flag, which is `true`
-only if every iteration kept it set.
+no short-circuit branch. The loop body is load, compare, compare, and,
+store. After the last byte we return the flag.
 
-The other way to write this, which I prefer when I am looking for
-problems rather than confirming that everything is valid, is to
-accumulate errors with OR:
+I prefer the dual form when I am looking for problems rather than
+confirming that everything is valid. Accumulate errors with OR:
 
-```cpp title="Branchless accumulation with bitwise OR"
+```cpp title="Branchless accumulation with OR"
 bool is_ascii_lowercase(std::string_view input) {
   unsigned errors = 0;
   for (unsigned char c : input) {
@@ -110,19 +83,18 @@ bool is_ascii_lowercase(std::string_view input) {
 }
 ```
 
-On x86 those compares compile to `setcc`, or a `cmp` plus something
-like `adc`. That is a flag write, not a jump. The loop always runs to
-completion, which is exactly what you want when the happy path is that
-the whole string is fine. It is also what the vectorizer wants to see.
+On x86 those compares compile to `setcc`. That is a flag write, not a
+jump. The loop always runs to completion. That is what you want when
+the happy path is that the whole string is fine, and it is what the
+vectorizer wants to see.
 
-We still have two comparisons per byte. The next step is to make the
-check itself cheaper.
+We still have two comparisons per byte. We can do better.
 
-## Bitwise operations: one compare, no short-circuit
+## One compare: the wraparound test
 
-A byte is an ASCII lowercase letter if and only if it sits in the
-closed range `['a', 'z']`. If we subtract `'a'`, that statement becomes
-"the result fits in 0 to 25".
+A byte is an ASCII lowercase letter if and only if it sits in
+`['a', 'z']`. Subtract `'a'` and that statement becomes "the result
+fits in 0 to 25".
 
 ```cpp title="Range check that wraps into a single unsigned compare"
 static inline bool is_lower(unsigned char c) {
@@ -133,18 +105,14 @@ static inline bool is_lower(unsigned char c) {
 Let's walk through a few values:
 
 - `'a' - 'a'` is `0`, and `0 <= 25`.
-- `'m' - 'a'` is `12`, still in range.
 - `'z' - 'a'` is `25`, still in range.
 - `` '`' - 'a' `` wraps to `255`, and `255 <= 25` is false.
 - `'{' - 'a'` is `26`, just outside.
 - `'A' - 'a'` wraps well above 25, so uppercase is rejected.
 
-The wraparound is the trick. Bytes below `'a'` underflow modulo 256
-and land in the high end of the `unsigned char` range, where they fail
-the same `<= 25` test as bytes above `'z'`. Two comparisons become one,
-and that one has no short-circuit.
-
-We can drop it into the accumulating loop:
+Bytes below `'a'` underflow modulo 256 and land in the high end of the
+`unsigned char` range, where they fail the same `<= 25` test as bytes
+above `'z'`. Two comparisons become one.
 
 ```cpp title="Validating a string with a wraparound predicate"
 bool is_ascii_lowercase(std::string_view input) {
@@ -158,45 +126,34 @@ bool is_ascii_lowercase(std::string_view input) {
 ```
 
 The body is now subtract, compare, or. There is no `if`, no `return` in
-the middle, and no `||`. For a simple contiguous class like `a-z`, this
+the middle, and no `||`. For a single closed interval like `a-z`, this
 is usually as far as scalar code needs to go.
 
-The wraparound test only works for a single closed interval. If you
-want to know whether a character is a hex digit, an unreserved URL
-character, or a forbidden host character, those classes are unions of
-ranges and punctuation. Bitwise arithmetic gets ugly there. A table
-does not.
+The wraparound test only works for one interval. Hex digits, unreserved
+URL characters, and forbidden host code points are unions of ranges
+and punctuation. Bitwise arithmetic gets ugly there. A table does not.
 
 ## A 256-byte lookup table
 
-You will sometimes hear people say "a table of size 255". The last
+A simple way to classify a byte is to generate a 256-element array and
+look the value up. Daniel calls this [memoization][tables] (and not
+memorization). You will sometimes hear "a table of size 255". The last
 valid index of an 8-bit value is 255, but the length of the array is
 **256**. Byte values run from `0x00` through `0xFF` inclusive. A table
-of 255 entries leaves `0xFF` unmapped and invites an off-by-one the
-first time a non-ASCII byte shows up.
+of 255 entries leaves `0xFF` unmapped.
 
-For ASCII classification, that 256-byte table covers every possible
-input. Every byte is a valid index, so the check cannot branch on the
-character itself. It can only load.
+Using C++17, you can have the compiler build the array at compile time
+from a lambda:
 
 ```cpp title="Build a 256-entry lowercase table at compile time"
-consteval std::array<uint8_t, 256> make_lowercase_table() {
+static constexpr std::array<uint8_t, 256> kIsLower = []() {
   std::array<uint8_t, 256> table{};
   for (unsigned c = 'a'; c <= 'z'; ++c) {
     table[c] = 1;
   }
   return table;
-}
+}();
 
-constexpr auto kIsLower = make_lowercase_table();
-```
-
-`table{}` zero-initializes every slot. The loop turns on only `'a'`
-through `'z'`. Uppercase, digits, punctuation, and bytes above 127 stay
-`0`. The table is 256 bytes, which is four cache lines. It stays hot if
-this function is actually on the hot path.
-
-```cpp title="Classify each byte with a load instead of a compare"
 bool is_ascii_lowercase(std::string_view input) {
   uint8_t ok = 1;
   for (unsigned char c : input) {
@@ -206,23 +163,22 @@ bool is_ascii_lowercase(std::string_view input) {
 }
 ```
 
-There is no `if (c >= 'a' && c <= 'z')`. There is a load from
-`kIsLower[c]` and an AND. The branch predictor has nothing to do. The
-same skeleton handles checks that would be miserable as arithmetic.
+`table{}` zero-initializes every slot. The loop turns on only `'a'`
+through `'z'`. Everything else stays `0`. Each character is checked
+with a single load, plus an AND. This might compile down to a single
+lookup instruction.
 
-A hex-digit table is a good next example, because hex is two ranges
-plus a gap:
+It takes a bit more effort, but the same skeleton handles checks that
+would be miserable as arithmetic. Hex is two ranges plus a gap:
 
 ```cpp title="Hex digits are a messy range and a clean table"
-consteval std::array<uint8_t, 256> make_hex_table() {
+static constexpr std::array<uint8_t, 256> kIsHex = []() {
   std::array<uint8_t, 256> table{};
   for (unsigned c = '0'; c <= '9'; ++c) table[c] = 1;
   for (unsigned c = 'a'; c <= 'f'; ++c) table[c] = 1;
   for (unsigned c = 'A'; c <= 'F'; ++c) table[c] = 1;
   return table;
-}
-
-constexpr auto kIsHex = make_hex_table();
+}();
 
 bool is_ascii_hex(std::string_view input) {
   uint8_t ok = 1;
@@ -235,36 +191,54 @@ bool is_ascii_hex(std::string_view input) {
 
 The scalar version of that check is
 `(c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')`.
-That is six comparisons and a tree of short-circuit branches, or one
-load.
+Six comparisons and a tree of short-circuit branches, or one load.
 
-This is how Ada classifies URL characters. Host, path, and
-percent-encoding rules are not a single interval. They are a pile of
-allowed and forbidden bytes. A 256-byte table per class is cheaper than
-explaining those rules to the branch predictor, and it is cheap enough
-that we keep one table per class rather than packing bits until the
-code is unreadable.
+This is how Ada classifies URL characters. [Daniel's compile-time
+table post][tables] uses the same idea for forbidden host code points:
+`'\0'`, tab, space, `#`, `/`, `:`, and so on. Those are not a single
+interval. They are a pile of allowed and forbidden bytes. A 256-byte
+table per class is cheaper than explaining those rules to the branch
+predictor.
 
-There are two caveats:
+Two caveats:
 
-- The table must be indexed with `unsigned char`. A signed `char` of
-  `0xFF` becomes `-1` and walks off the front of the array.
-- A table only wins if it stays in cache. 256 bytes is easy. Rebuilding
-  a table on every call is not a table. It is extra work.
+- Index the table with `uint8_t` or `unsigned char`. A signed `char`
+  of `0xFF` becomes `-1` and walks off the front of the array.
+- A table only wins if it stays in cache. 256 bytes is four cache
+  lines. Rebuilding the table on every call is extra work, not a
+  table.
 
-We are still doing one load per byte. The next two sections do eight
-and sixteen bytes per iteration.
+In [Daniel's escaping benchmark][escaping], the table-based approach
+is quite competitive (around 1.9 GB/s on GCC). LLVM can autovectorize
+the branchless loop well enough that it sometimes beats the table. In
+every case he measured, hand-written SIMD was at least twice as fast.
+
+Can we do better?
 
 ## SWAR when SIMD is not available
 
-SWAR means SIMD within a register. You treat a `uint64_t` as eight
-packed bytes and use ordinary integer arithmetic (add, subtract, and,
-and not) to run the same test on all eight lanes at once. There is no
-`#include <arm_neon.h>`, no AVX, and no runtime dispatch. The code is
-portable C++.
+If you do not have SIMD, or you do not want a runtime ISA dispatch,
+you can still process eight bytes at a time. The technique is called
+SWAR: SIMD within a register. [Lamport described it in 1975][swar].
+The intuition is that modern computers have 64-bit registers.
+Processing eight consecutive bytes as eight distinct words is
+inefficient given how wide our registers are.
 
-The building block is splat: repeat a byte eight times so it lines up
-with every lane.
+The first step is to load eight characters into a `uint64_t`. In C++,
+you might do it this way:
+
+```cpp title="Load eight bytes into a register"
+uint64_t word;
+std::memcpy(&word, chars, 8);
+```
+
+It looks maybe expensive, but most compilers will translate the
+`memcpy` into a single load when optimizations are on.
+
+We then treat that register as a vector of eight bytes and use
+ordinary integer arithmetic on all of them at once. [Daniel's SWAR
+posts][swar-json] are the best explanation I know. The building block
+is to repeat a constant across every lane:
 
 ```cpp title="Broadcast one byte across a 64-bit word"
 constexpr uint64_t kOnes = 0x0101010101010101ULL;
@@ -276,12 +250,16 @@ constexpr uint64_t splat(uint8_t x) {
 ```
 
 `splat('a')` is `0x6161616161616161`. `kHigh` is a mask of the top bit
-of every byte. That high bit is our per-lane boolean. `0x80` means this
-byte failed. `0x00` means it did not.
+of every byte. That high bit is our per-lane boolean. `0x80` means
+this byte failed. `0x00` means it did not.
 
-Two tests from [Bit Twiddling Hacks][bithacks] tell us whether any lane
-is below or above a constant. They look like magic, so here is the
-actual contract:
+If you have 8 bytes in a 64-bit word `x`, computing
+`x - splat(32)` subtracts 32 from each byte. It works well if each
+byte is greater than or equal to 32. Otherwise the operation
+overflows: if the least significant byte is too small, its most
+significant bit is set, and you cannot rely on the other lanes. That
+is why we first keep only ASCII bytes (`x & kHigh` is zero when every
+byte is below 128), and then apply both bounds.
 
 ```cpp title="Per-byte comparisons inside a uint64_t"
 // High bit set in each byte of x that is strictly less than n.
@@ -295,19 +273,7 @@ constexpr uint64_t bytes_less_than(uint64_t x, uint8_t n) {
 constexpr uint64_t bytes_greater_than(uint64_t x, uint8_t n) {
   return ((x + splat(127 - n)) | x) & kHigh;
 }
-```
 
-`bytes_less_than` subtracts `n` from each byte. A lane that was already
-below `n` underflows, and the `& ~x & kHigh` filter keeps only those
-underflows. `bytes_greater_than` adds `127 - n`. A lane above `n`
-crosses 127 and lights the high bit. The `| x` term also catches bytes
-that already had their high bit set.
-
-For ASCII input, those additions and subtractions do not carry into the
-next lane in a way that breaks the test, because every byte is below
-128. So we reject non-ASCII first, then apply both bounds:
-
-```cpp title="Eight lowercase checks in one uint64_t"
 bool eight_bytes_are_lowercase(uint64_t word) {
   const uint64_t non_ascii = word & kHigh;
   const uint64_t too_small = bytes_less_than(word, 'a');
@@ -316,15 +282,20 @@ bool eight_bytes_are_lowercase(uint64_t word) {
 }
 ```
 
-If `word` is eight lowercase letters, every lane sits in `['a', 'z']`
-and the three masks are zero. If one lane is `'A'` or `'{'` or `0xC3`,
-the corresponding high bit in the OR is set and the function returns
-`false`.
+`bytes_less_than` subtracts `n` from each byte. A lane that was
+already below `n` underflows, and the `& ~x & kHigh` filter keeps only
+those underflows. `bytes_greater_than` adds `127 - n`. A lane above
+`n` crosses 127 and lights the high bit.
 
-The string-level version loads eight bytes at a time with `memcpy`.
-That is the portable way to avoid alignment and strict-aliasing
-problems. It ORs the failure masks into an accumulator, and finishes
-the leftover bytes with the scalar wraparound test.
+If `word` is eight lowercase letters, the three masks are zero. If one
+lane is `'A'` or `'{'` or `0xC3`, the corresponding high bit in the OR
+is set.
+
+The string-level version ORs the failure masks into an accumulator and
+finishes the leftover bytes with the scalar wraparound test. That's
+slightly more than one operation per input byte in the main loop,
+which is the same claim Daniel makes for his JSON-escapable SWAR
+check.
 
 ```cpp title="SWAR lowercase scan with a scalar tail"
 bool is_ascii_lowercase(std::string_view input) {
@@ -352,80 +323,88 @@ bool is_ascii_lowercase(std::string_view input) {
 ```
 
 The inner loop never branches on a character value. It always consumes
-eight bytes, always updates `bad`, and always continues. That is the
-same OR-accumulation idea as the scalar version, applied to a whole
-word. The leftover `n < 8` bytes are not worth the SWAR setup. The
-wraparound check is enough.
+eight bytes, always updates `bad`, and always continues. The leftover
+`n < 8` bytes are not worth the SWAR setup.
 
-SWAR is the right tool when you do not have SIMD, when you do not want
-a runtime ISA dispatch, or when the leftover after a SIMD main loop is
-still several words long. It is also a good way to understand the SIMD
-code, because NEON is the same algorithm with 16-byte registers and
-real compare instructions.
+SWAR is also a good way to understand the SIMD code. NEON is the same
+algorithm with 16-byte registers and real compare instructions.
 
 ## The same check with NEON
 
-[ARM NEON][neon] gives you 128-bit vectors. One load brings in sixteen
-bytes. One compare produces sixteen lanes of `0xFF` or `0x00`. One OR
-accumulates failures. There is no SWAR carry trick here, because the
-hardware already knows the lanes are independent.
+[ARM NEON][neon] can process 16 bytes at a time. One load, one
+compare, one OR. There is no SWAR carry trick, because the hardware
+already knows the lanes are independent. For the most part, your
+computer is either an ARM machine supporting at least NEON, or an x64
+machine supporting at least SSE2. It is easy to distinguish at compile
+time.
+
+A good general strategy, which Daniel uses in the [escaping
+post][escaping], is to load the data in blocks of 16 bytes and do a
+few comparisons over those 16 bytes. What about fewer than 16
+characters? If you do not want to read past the string, fall back on
+one of the conventional functions. If the leftover is non-empty but
+the string was already at least 16 bytes, you can reload the last 16
+bytes of the input. That overlapping load avoids a scalar tail.
 
 ```cpp title="NEON lowercase scan, 16 bytes per iteration"
 #include <arm_neon.h>
 
 bool is_ascii_lowercase(std::string_view input) {
+  if (input.size() < 16) {
+    unsigned errors = 0;
+    for (unsigned char c : input) {
+      errors |= static_cast<unsigned>(
+          static_cast<unsigned char>(c - 'a') > 25);
+    }
+    return errors == 0;
+  }
+
   const auto* p = reinterpret_cast<const uint8_t*>(input.data());
   size_t n = input.size();
-
   uint8x16_t errors = vdupq_n_u8(0);
   const uint8x16_t va = vdupq_n_u8('a');
   const uint8x16_t vz = vdupq_n_u8('z');
 
-  while (n >= 16) {
-    const uint8x16_t v = vld1q_u8(p);
+  size_t i = 0;
+  for (; i + 15 < n; i += 16) {
+    const uint8x16_t v = vld1q_u8(p + i);
     const uint8x16_t in_range = vandq_u8(vcgeq_u8(v, va), vcleq_u8(v, vz));
     errors = vorrq_u8(errors, vmvnq_u8(in_range));
-    p += 16;
-    n -= 16;
+  }
+  if (i < n) {
+    const uint8x16_t v = vld1q_u8(p + n - 16);
+    const uint8x16_t in_range = vandq_u8(vcgeq_u8(v, va), vcleq_u8(v, vz));
+    errors = vorrq_u8(errors, vmvnq_u8(in_range));
   }
 
-  if (vmaxvq_u8(errors) != 0) {
-    return false;
-  }
-
-  while (n--) {
-    if (static_cast<unsigned char>(*p++ - 'a') > 25) {
-      return false;
-    }
-  }
-  return true;
+  return vmaxvq_u8(errors) == 0;
 }
 ```
 
 Here is what each intrinsic is doing:
 
 - `vdupq_n_u8('a')` is the NEON splat. Every lane holds `'a'`.
-- `vld1q_u8` loads 16 consecutive bytes. You do not need `memcpy`
-  here. The instruction accepts unaligned addresses.
+- `vld1q_u8` loads 16 consecutive bytes. The instruction accepts
+  unaligned addresses, so you do not need `memcpy`.
 - `vcgeq_u8` / `vcleq_u8` compare every lane against `'a'` and `'z'`.
   A passing lane becomes `0xFF`. A failing lane becomes `0x00`.
 - `vandq_u8` of those two masks is the closed interval `['a', 'z']`.
 - `vmvnq_u8` flips it, so errors are `0xFF`.
-- `vorrq_u8` into `errors` is the same OR-accumulation as the scalar
-  and SWAR loops.
+- `vorrq_u8` into `errors` is the same OR-accumulation as before.
 - `vmaxvq_u8` (AArch64) reduces the vector. If any lane is non-zero,
   some byte was out of range.
 
-The tail is scalar on purpose. Sixteen bytes and up is where NEON pays
-for the load. The leftover 0 to 15 bytes are cheaper as the wraparound
-test.
+The magic of SIMD is that it can do 16 comparisons at once. You can
+optimize the function further to reduce the number of instructions,
+but it already uses far fewer when processing blocks of 16 bytes than
+the conventional functions.
 
 For a single interval, vector compares beat a table. For messier
-classes such as hex, URL unreserved characters, or JSON string-safe
-bytes, NEON can still do the table lookup. It just cannot do it as a
-256-byte gather. The usual trick, which [simdjson][simdjson]
-popularized and which we use in Ada, is to split each byte into
-nibbles and look those up in two 16-byte tables.
+classes, the 256-byte table fails: there is no 256-byte gather on
+NEON. The usual trick is [vectorized classification][neon-ids] (see
+Langdale and Lemire, [Parsing Gigabytes of JSON per Second][pgjson]).
+We use the same idea in Ada. Split each byte into two 4-bit nibbles
+and look those up in two 16-byte tables:
 
 ```cpp title="Nibble lookup: a 256-byte class table in two 16-byte vectors"
 uint8x16_t classify(uint8x16_t input,
@@ -440,15 +419,17 @@ uint8x16_t classify(uint8x16_t input,
 `vqtbl1q_u8` is a 16-entry table lookup done on all sixteen lanes at
 once. The low nibble picks a row, the high nibble picks a row, and the
 AND is 1 only when both halves of the original 256-entry table would
-have said yes. You are back to the lookup-table section, except the
-table now lives in registers and you classify 16 bytes per call.
+have said yes. The table now lives in registers and you classify 16
+bytes per call.
 
 On x86 the same ideas map to SSE/AVX (`_mm_cmpeq_epi8`,
 `_mm_shuffle_epi8`). The NEON names change. The loop shape does not.
 
 ## Which one should you use?
 
-Use the technique that matches the check and the length of the input.
+It can be tricky to pick. Results depend on your compiler, your
+processor, and your data. Use the technique that matches the check and
+the length of the input.
 
 1. **Early `return false`** when invalid input is common and usually
    fails in the first few bytes. Do not be clever if the branch is
@@ -456,6 +437,8 @@ Use the technique that matches the check and the length of the input.
 2. **Bitwise accumulation** when you already scan the whole string and
    the check is a single interval. The wraparound test
    (`unsigned char(c - 'a') <= 25`) is the whole optimization.
+   Compilers at `-O3` can turn this into `cmov` / `setcc`, and LLVM
+   in particular may autovectorize it.
 3. **A 256-byte table** when the check is a union of ranges or a mix
    of punctuation. One load replaces a tree of compares. Size it at
    256, not 255.
@@ -466,11 +449,9 @@ Use the technique that matches the check and the length of the input.
    input is tens of bytes or more. Use compare instructions for
    intervals, and nibble tables for everything else.
 
-Compilers at `-O3` already turn some of the scalar loops into `cmov`
-or `setcc`, and they can even auto-vectorize them. They will not invent
-a 256-byte character class for you, and they will not write the SWAR
-masks. Measure the version you are about to delete. If the naive loop
-is already off the profile, leave it alone.
+Compilers will not invent a 256-byte character class for you, and they
+will not write the SWAR masks. Measure the version you are about to
+delete. If the naive loop is already off the profile, leave it alone.
 
 I used "is this string ASCII lowercase?" as the running example
 because the check is small enough to see every transformation. In
@@ -480,6 +461,11 @@ that show up in a URL parser, and they are often where a simple
 `for` loop with an early `return` becomes the bottleneck.
 
 [ada]: https://github.com/ada-url/ada
-[bithacks]: https://graphics.stanford.edu/~seander/bithacks.html#HasLessInWord
+[lemire]: https://lemire.me
+[escaping]: https://lemire.me/blog/2024/05/31/quickly-checking-whether-a-string-needs-escaping/
+[tables]: https://lemire.me/blog/2023/11/07/generating-arrays-at-compile-time-in-c-with-lambdas/
+[swar]: https://lemire.me/blog/2022/01/21/swar-explained-parsing-eight-digits/
+[swar-json]: https://lemire.me/blog/2025/04/13/detect-control-characters-quotes-and-backslashes-efficiently-using-swar/
+[neon-ids]: https://lemire.me/blog/2023/09/04/locating-identifiers-quickly-arm-neon-edition/
+[pgjson]: https://arxiv.org/abs/1902.08318
 [neon]: https://developer.arm.com/architectures/instruction-sets/intrinsics/
-[simdjson]: https://github.com/simdjson/simdjson

--- a/src/content/blog/eliminating-branches-in-cpp-loops.mdx
+++ b/src/content/blog/eliminating-branches-in-cpp-loops.mdx
@@ -3,7 +3,8 @@ title: 'Eliminating branches in C++ loops'
 description: >-
   A for loop that returns false from a branch and true at the end is easy
   to read, but the branch can be expensive. In this post I show how to
-  remove it with bitwise operations, a 256-byte table, SWAR, and NEON.
+  remove it with bitwise operations, a 256-byte table, SWAR, and NEON,
+  and then apply the same ideas to UTF-16 validation.
 date: '2026-08-22'
 tag: performance
 status: published
@@ -545,6 +546,175 @@ unreserved, forbidden host bytes, whitespace. Those are the loops
 that show up in a URL parser, and they are often where a simple
 `for` loop with an early `return` becomes the bottleneck.
 
+The same tools also apply when the check is no longer independent
+per byte. UTF-16 is the example I reach for.
+
+## A harder problem: is this valid UTF-16?
+
+ASCII lowercase is a per-byte question. Each character stands on
+its own. UTF-16 does not work that way.
+
+A UTF-16 string is a sequence of 16-bit code units. Most of Unicode
+fits in one unit. That is the Basic Multilingual Plane: everything
+from `U+0000` to `U+D7FF` and from `U+E000` to `U+FFFF`. Characters
+above `U+FFFF` use two units, a surrogate pair. The first unit is a
+high surrogate (`U+D800` to `U+DBFF`). The second is a low surrogate
+(`U+DC00` to `U+DFFF`). A high surrogate must be followed by a low
+surrogate. A low surrogate must be preceded by a high surrogate.
+Anything else is invalid.
+
+Windows, Java, and JavaScript all store strings this way. [Daniel
+has a post][utf16-neon] on fixing broken UTF-16 in place with NEON.
+[simdutf][simdutf] is the production version of the same idea. The
+question I want is simpler: is this input valid UTF-16?
+
+A reasonable function looks a lot like the loop we started with.
+We return `false` from a branch, and `true` at the end.
+
+```cpp title="The obvious UTF-16 validator"
+static inline bool is_high_surrogate(char16_t c) {
+  return static_cast<uint16_t>(c - 0xD800) <= 0x03FF;
+}
+
+static inline bool is_low_surrogate(char16_t c) {
+  return static_cast<uint16_t>(c - 0xDC00) <= 0x03FF;
+}
+
+bool is_valid_utf16(std::u16string_view input) {
+  for (size_t i = 0; i < input.size();) {
+    const char16_t u = input[i];
+    if (static_cast<uint16_t>(u - 0xD800) > 0x07FF) {
+      ++i;
+      continue;
+    }
+    if (!is_high_surrogate(u) || i + 1 >= input.size() ||
+        !is_low_surrogate(input[i + 1])) {
+      return false;
+    }
+    i += 2;
+  }
+  return true;
+}
+```
+
+The wraparound test is back. `(u - 0xD800) > 0x07FF` means "not a
+surrogate at all". `(u - 0xD800) <= 0x03FF` means high.
+`(u - 0xDC00) <= 0x03FF` means low. You can also do it with a mask,
+which I like better here:
+
+```cpp title="Classify a code unit with a mask"
+static inline bool is_surrogate(char16_t c) {
+  return (c & 0xF800) == 0xD800;
+}
+
+static inline bool is_high_surrogate(char16_t c) {
+  return (c & 0xFC00) == 0xD800;
+}
+
+static inline bool is_low_surrogate(char16_t c) {
+  return (c & 0xFC00) == 0xDC00;
+}
+```
+
+`0xD800` to `0xDFFF` all have the top five bits `11011`. That is
+what `c & 0xF800` tests. High vs low is the next two bits.
+
+This is already harder than lowercase. The predicate looks at the
+next unit. You have state. A lone high at the end of the string is
+an error. A lone low in the middle is an error. Two highs in a row
+are an error. You cannot AND a per-unit flag and be done.
+
+A 256-byte table does not help much either. The input is 16-bit.
+A table of 65536 entries is 64 KiB. That is no longer four cache
+lines.
+
+What does help is the same observation we used for lowercase: most
+input is fine. Most UTF-16 text never leaves the BMP. There are no
+surrogates at all. If a block has no word in `0xD800..0xDFFF`, the
+whole block is valid and we can skip it.
+
+SWAR can do that for four code units in a `uint64_t`:
+
+```cpp title="Any surrogate in four UTF-16 code units?"
+constexpr uint64_t kSurrogateBits = 0xF800F800F800F800ULL;
+constexpr uint64_t kSurrogateWant = 0xD800D800D800D800ULL;
+constexpr uint64_t kLaneHigh = 0x8000800080008000ULL;
+constexpr uint64_t kLaneOne = 0x0001000100010001ULL;
+
+bool has_surrogate_word(uint64_t word) {
+  const uint64_t xor_lanes = (word & kSurrogateBits) ^ kSurrogateWant;
+  return ((xor_lanes - kLaneOne) & ~xor_lanes & kLaneHigh) != 0;
+}
+```
+
+Mask each 16-bit lane with `0xF800`, XOR with `0xD800`, and look
+for a zero lane. If there is none, those four units are valid. If
+there is one, we fall back to the scalar pairing loop for that
+block. That is the same OR-accumulation idea, except the cheap
+path is "no surrogates" and the expensive path is the state
+machine.
+
+On NEON you load eight code units and do the pairing in the
+vector. The trick is to build a high-surrogate mask and a
+low-surrogate mask, then shift one of them so each lane is
+checked against its neighbor. The last high-surrogate bit of the
+previous block has to come along. That carry is the whole
+difference from the lowercase scan.
+
+```cpp title="NEON UTF-16 block: pair surrogates across lanes"
+bool is_valid_utf16_block(uint16x8_t vec, bool& pending_high) {
+  const uint16x8_t high = vceqq_u16(
+      vandq_u16(vec, vdupq_n_u16(0xFC00)), vdupq_n_u16(0xD800));
+  const uint16x8_t low = vceqq_u16(
+      vandq_u16(vec, vdupq_n_u16(0xFC00)), vdupq_n_u16(0xDC00));
+
+  if (pending_high && vgetq_lane_u16(low, 0) == 0) {
+    return false;
+  }
+
+  const uint16x8_t prev = vdupq_n_u16(pending_high ? 0xFFFF : 0);
+  const uint16x8_t high_before = vextq_u16(prev, high, 7);
+  const uint16x8_t low_after = vextq_u16(low, vdupq_n_u16(0), 1);
+
+  const uint16x8_t lone_low = vbicq_u16(low, high_before);
+  uint16x8_t lone_high = vbicq_u16(high, low_after);
+  lone_high = vsetq_lane_u16(0, lone_high, 7);
+
+  pending_high = vgetq_lane_u16(high, 7) != 0;
+  return vmaxvq_u16(vorrq_u16(lone_low, lone_high)) == 0;
+}
+```
+
+`vextq_u16(prev, high, 7)` takes the last lane of the previous
+high-surrogate mask and puts it in front of the current one. Each
+low lane is then checked against the high that came before it.
+`vbicq` is AND-NOT: a low with no high in front of it, or a high
+with no low after it.
+
+The last lane is the carry. If this block ends on a high
+surrogate, we do not fail yet. We set `pending_high` and let the
+next block pair it. If the next block starts with anything other
+than a low surrogate, that is an error. If `pending_high` is still
+set after the last block, the string ended on a lone high
+surrogate and we return `false`. That is the one piece of state
+the lowercase scan never needed.
+
+You can go further the way a reader did on Daniel's post. NEON
+can deinterleave with `vld2q_u8`: even bytes in one register, odd
+bytes in the other. For little-endian UTF-16, the high byte of
+each code unit is enough to tell high surrogate, low surrogate,
+or neither. You throw away the low bytes and classify 16 units
+from one 16-byte register. [The follow-up paper][utf16-paper]
+pushes that idea to 64-unit blocks.
+
+The point is not to paste a production validator into a blog
+post. [simdutf][simdutf] already has one. The point is that the
+ladder did not change. You still want fewer branches. You still
+want a cheap test that rejects the common case without pairing.
+You still want SIMD when the strings are long. The new cost is
+the carry: one bit of state between blocks, because UTF-16 is a
+tiny state machine and lowercase is not.
+
 [ada]: https://github.com/ada-url/ada
 [lemire]: https://lemire.me
 [escaping]: https://lemire.me/blog/2024/05/31/quickly-checking-whether-a-string-needs-escaping/
@@ -554,3 +724,6 @@ that show up in a URL parser, and they are often where a simple
 [neon-ids]: https://lemire.me/blog/2023/09/04/locating-identifiers-quickly-arm-neon-edition/
 [pgjson]: https://arxiv.org/abs/1902.08318
 [neon]: https://developer.arm.com/architectures/instruction-sets/intrinsics/
+[utf16-neon]: https://lemire.me/blog/2024/12/29/efficient-in-place-utf-16-unicode-correction-with-arm-neon/
+[simdutf]: https://github.com/simdutf/simdutf
+[utf16-paper]: https://arxiv.org/abs/2601.06349


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a new performance post that starts from a validating `for` loop (early `return false`, `return true` at the end) and shows how to delete the branch.

The structure follows Daniel Lemire's writeups on the same ladder ([escaping](https://lemire.me/blog/2024/05/31/quickly-checking-whether-a-string-needs-escaping/), [compile-time tables](https://lemire.me/blog/2023/11/07/generating-arrays-at-compile-time-in-c-with-lambdas/), [SWAR](https://lemire.me/blog/2022/01/21/swar-explained-parsing-eight-digits/), [NEON classification](https://lemire.me/blog/2023/09/04/locating-identifiers-quickly-arm-neon-edition/)).

The last section is a harder problem: is this valid UTF-16? It follows [Daniel's UTF-16 NEON post](https://lemire.me/blog/2024/12/29/efficient-in-place-utf-16-unicode-correction-with-arm-neon/) more closely: how the encoding works, a basic function, a full eight-wide NEON validator with wraparound classification and a one-vector carry, then the reader's interleaved-load (`vld2q_u8`) follow-up. Includes his M2 numbers for the correction version (1.7 / 5.5 / 13 GB/s). Production pointer is [simdutf](https://github.com/simdutf/simdutf).

Prose stays in the conversational register of the rest of the blog and does not use em dashes. The post is published and tagged `performance`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02a20-6340-7f9b-8073-b79b56e7f2b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02a20-6340-7f9b-8073-b79b56e7f2b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

