### PR TITLE
Add richer JSON-LD, microdata, and page-level SEO fixes

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -113,8 +113,8 @@ export default defineConfig({
   integrations: [
     mdx(),
     sitemap({
-      lastmod: new Date(),
       // Markdown / llms endpoints are for agents; keep them out of the HTML sitemap.
+      // Do not stamp every URL with the build clock — Google treats that lastmod as noise.
       filter: (page) => !isMarkdownOrLlmsAsset(page),
     }),
   ],

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
+Disallow: /api/
 
 # LLM-oriented discovery
 # https://www.yagiz.co/llms.txt

--- a/src/components/BlogFooter.astro
+++ b/src/components/BlogFooter.astro
@@ -6,6 +6,7 @@ import { ArrowLeft, ArrowRight } from '@lucide/astro'
 import authorImg from '@/assets/author-image.png'
 import Container from '@/components/ui/Container.astro'
 import { authorFullName } from '@/lib/content'
+import { schemaIds } from '@/lib/schema'
 
 interface Props {
   index: number
@@ -33,13 +34,20 @@ const previous = index !== posts.length - 1 ? posts.at(index + 1) : undefined
     }
   </div>
 
-  <div class="flex flex-col">
+  <div
+    class="flex flex-col"
+    itemprop="author"
+    itemscope
+    itemtype="https://schema.org/Person"
+    itemid={schemaIds.person}
+  >
     <div class="flex flex-col items-center gap-y-4">
       <p class="mb-4 font-extrabold tracking-wide text-slate-800 dark:text-white">
         Published by:
       </p>
       <a
         href="/about"
+        itemprop="url"
         aria-label={`About ${authorFullName}`}
         class="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 rounded-full"
       >
@@ -49,8 +57,10 @@ const previous = index !== posts.length - 1 ? posts.at(index + 1) : undefined
           width={50}
           height={50}
           class="rounded-full"
+          itemprop="image"
         />
       </a>
+      <meta itemprop="name" content={authorFullName} />
     </div>
   </div>
 

--- a/src/components/BlogRow.astro
+++ b/src/components/BlogRow.astro
@@ -1,26 +1,36 @@
 ---
 import type { CollectionEntry } from 'astro:content'
 import { ChevronRight } from '@lucide/astro'
+import { readingTimeLabel } from '@/lib/reading-time'
+import { absoluteUrl } from '@/lib/schema'
 
 interface Props {
   post: CollectionEntry<'blog'>
+  itemprop?: string
 }
 
-const { post } = Astro.props
-const words = (post.body ?? '').trim().split(/\s+/).length
-const minute_to_read = `${Math.max(1, Math.round(words / 200))} min read`
+const { post, itemprop } = Astro.props
+const minute_to_read = readingTimeLabel(post.body)
 const formattedDate = new Intl.DateTimeFormat('en-US', {
   month: 'short',
   day: 'numeric',
 }).format(post.data.date)
+const url = absoluteUrl(`/${post.id}`)
 ---
 
 <a
   href={`/${post.id}`}
   class="group relative flex items-center overflow-hidden py-3"
+  itemscope
+  itemtype="https://schema.org/BlogPosting"
+  itemid={`${url}#blogposting`}
+  itemprop={itemprop}
 >
+  <link itemprop="url" href={url} />
+  <meta itemprop="description" content={post.data.description} />
   <time
     datetime={post.data.date.toISOString()}
+    itemprop="datePublished"
     class="mr-6 flex min-w-[45px] whitespace-nowrap text-xs font-extrabold uppercase text-orange-400"
   >
     {formattedDate}
@@ -30,6 +40,7 @@ const formattedDate = new Intl.DateTimeFormat('en-US', {
   >
     <h2
       class="truncate font-normal dark:text-white dark:group-hover:text-neutral-300 group-hover:text-slate-600"
+      itemprop="headline"
     >
       {post.data.title}
     </h2>

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -1,0 +1,52 @@
+---
+import { absoluteUrl, type BreadcrumbItem } from '@/lib/schema'
+
+interface Props {
+  items: BreadcrumbItem[]
+}
+
+const { items } = Astro.props
+---
+
+<nav aria-label="Breadcrumb" class="text-xs font-bold">
+  <ol
+    class="flex flex-wrap items-center justify-center gap-y-1 text-neutral-500 dark:text-neutral-400"
+    itemscope
+    itemtype="https://schema.org/BreadcrumbList"
+  >
+    {
+      items.map((item, index) => {
+        const isLast = index === items.length - 1
+        return (
+          <li
+            class="flex max-w-full items-center"
+            itemscope
+            itemprop="itemListElement"
+            itemtype="https://schema.org/ListItem"
+          >
+            {index > 0 && (
+              <span aria-hidden="true" class="px-2 font-serif leading-[1] text-neutral-400">
+                /
+              </span>
+            )}
+            {isLast ? (
+              <span class="truncate" itemprop="name" aria-current="page">
+                {item.name}
+              </span>
+            ) : (
+              <a
+                class="text-orange-400 hover:text-orange-300"
+                href={item.path}
+                itemprop="item"
+              >
+                <span itemprop="name">{item.name}</span>
+              </a>
+            )}
+            {isLast && <link itemprop="item" href={absoluteUrl(item.path)} />}
+            <meta itemprop="position" content={String(index + 1)} />
+          </li>
+        )
+      })
+    }
+  </ol>
+</nav>

--- a/src/components/Page.astro
+++ b/src/components/Page.astro
@@ -1,21 +1,33 @@
 ---
 import { type CollectionEntry, render } from 'astro:content'
+import Breadcrumbs from '@/components/Breadcrumbs.astro'
 import { components } from '@/components/mdx'
 import Figure from '@/components/ui/Figure.astro'
 import Heading from '@/components/ui/Heading.astro'
 import Prose from '@/components/ui/Prose.astro'
+import type { BreadcrumbItem } from '@/lib/schema'
 
 interface Props {
   page: CollectionEntry<'pages'>
+  itemtype?: string
+  itemid?: string
+  breadcrumbs?: BreadcrumbItem[]
 }
 
-const { page } = Astro.props
+const { page, itemtype, itemid, breadcrumbs } = Astro.props
 const { Content } = await render(page)
 ---
 
-<section>
+<section {...(itemtype ? { itemscope: true, itemtype, itemid } : {})}>
   <header class="mb-[4.5rem] grid grid-cols-canvas text-center">
-    <Heading>{page.data.title}</Heading>
+    {
+      breadcrumbs && (
+        <div class="col-main mb-4">
+          <Breadcrumbs items={breadcrumbs} />
+        </div>
+      )
+    }
+    <Heading itemprop={itemtype ? 'name' : undefined}>{page.data.title}</Heading>
 
     {
       page.data.image && (
@@ -23,12 +35,13 @@ const { Content } = await render(page)
           alt={page.data.image.alt}
           src={page.data.image.src}
           caption={page.data.image.caption}
+          itemprop={itemtype ? 'image' : undefined}
         />
       )
     }
   </header>
 
-  <Prose>
+  <Prose itemprop={itemtype ? 'text' : undefined}>
     <Content {components} />
   </Prose>
 

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -7,14 +7,21 @@ export interface Item {
 }
 
 const footerItems: Item[] = [
+  { title: 'About', href: '/about' },
   { title: 'Press', href: '/press' },
+  { title: 'Newsletter', href: '/newsletter' },
   { title: 'Contact', href: '/contact' },
   { title: 'X', href: xUrl },
   { title: 'RSS', href: rssUrl },
 ]
 ---
 <footer class="flex flex-col items-center pb-20 pt-12 mx-auto w-full max-w-6xl gap-y-4">
-  <nav aria-label="Footer navigation" class="flex flex-wrap items-center justify-center">
+  <nav
+    aria-label="Footer navigation"
+    class="flex flex-wrap items-center justify-center"
+    itemscope
+    itemtype="https://schema.org/SiteNavigationElement"
+  >
     {
       footerItems.map((item, index) => (
         <a

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -25,7 +25,12 @@ const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.s
     </a>
   </div>
 
-  <nav aria-label="Main navigation" class="items-center md:flex">
+  <nav
+    aria-label="Main navigation"
+    class="items-center md:flex"
+    itemscope
+    itemtype="https://schema.org/SiteNavigationElement"
+  >
     {
       headerItems.map((item) => (
         <a

--- a/src/components/ui/Figure.astro
+++ b/src/components/ui/Figure.astro
@@ -6,21 +6,29 @@ interface Props {
   caption?: string | undefined
   src: ImageMetadata
   alt: string
+  itemprop?: string
 }
 
 const props = Astro.props
 ---
-<figure class="mt-6 col-wide">
+<figure
+  class="mt-6 col-wide"
+  itemscope
+  itemtype="https://schema.org/ImageObject"
+  itemprop={props.itemprop}
+>
   <Image
     src={props.src}
     alt={props.alt}
     width={920}
     loading="eager"
     class="duration-300 ease-in-out bg-gray-100 dark:bg-gray-900 aspect-[2/1] w-full object-cover object-center"
+    itemprop="contentUrl"
   />
+  <meta itemprop="name" content={props.alt} />
   {
     props.caption && (
-      <figcaption class="mt-4 text-sm text-neutral-400">
+      <figcaption class="mt-4 text-sm text-neutral-400" itemprop="caption">
         {props.caption}
       </figcaption>
     )

--- a/src/components/ui/Heading.astro
+++ b/src/components/ui/Heading.astro
@@ -1,5 +1,14 @@
+---
+interface Props {
+  itemprop?: string
+}
+
+const { itemprop } = Astro.props
+---
+
 <h1
   class="col-main text-4xl font-extrabold tracking-tight text-slate-800 dark:text-white"
+  itemprop={itemprop}
 >
   <slot />
 </h1>

--- a/src/components/ui/Prose.astro
+++ b/src/components/ui/Prose.astro
@@ -1,4 +1,14 @@
-<article
+---
+interface Props {
+  itemprop?: string
+  as?: 'article' | 'div'
+}
+
+const { itemprop, as: Tag = 'article' } = Astro.props
+---
+
+<Tag
+  itemprop={itemprop}
   class:list={[
     "grid grid-cols-canvas [&>*]:col-main",
     "max-w-none [&_p:has(img.col-wide)]:col-wide",
@@ -12,4 +22,4 @@
   ]}
 >
   <slot />
-</article>
+</Tag>

--- a/src/content/pages/contact.mdx
+++ b/src/content/pages/contact.mdx
@@ -1,7 +1,7 @@
 ---
 title: Contact
 description: >-
-  Latest articles, blog posts and press releases featuring Yagiz Nizipli and his projects.
+  Contact Yagiz Nizipli about software engineering, Node.js, and performance work.
 ---
 
 Easiest way to contact me is by completing the following form. I'll try to respond as soon as possible.

--- a/src/content/pages/newsletter.mdx
+++ b/src/content/pages/newsletter.mdx
@@ -1,7 +1,7 @@
 ---
 title: Sign up for newsletter
 description: >-
-  Easest way to get notified and follow the latest articles, blog posts and press releases featuring me and my projects.
+  Subscribe for updates on Yagiz Nizipli's writing about software engineering, Node.js, and performance.
 ---
 
 Please sign up for the newsletter to get notified about the latest articles, blog posts, and press releases featuring me and my projects.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,16 +10,20 @@ import {
   twitterUsername,
   websiteDescription,
   websiteTitle,
+  xUrl,
 } from '@/lib/content'
-import type { JsonLd } from '@/lib/schema'
+import { absoluteUrl, type JsonLd, pageCanonical } from '@/lib/schema'
 import '@/styles/globals.css'
 
 interface Props {
   title?: string
   description?: string
   image?: string
+  imageAlt?: string
   markdownUrl?: string
   jsonLd?: JsonLd | JsonLd[]
+  canonical?: string
+  robots?: string
   article?: {
     authors?: string[]
     publishedTime?: string
@@ -32,13 +36,24 @@ const {
   title,
   description = websiteDescription,
   image = `${Astro.url.origin}/opengraph-image.png`,
+  imageAlt,
   markdownUrl,
   jsonLd,
+  canonical,
+  robots = 'index, follow',
   article,
 } = Astro.props
 
 const pageTitle = title ? `${title} - ${websiteTitle}` : websiteTitle
 const jsonLdDocuments = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : []
+const selfUrl = pageCanonical(Astro.url.pathname)
+const canonicalUrl = pageCanonical(Astro.url.pathname, canonical)
+const socialTitle = title ?? websiteTitle
+const socialImageAlt = imageAlt ?? socialTitle
+const noindex = robots.includes('noindex')
+const googlebot = noindex
+  ? robots
+  : 'index, follow, max-video-preview:-1, max-image-preview:large, max-snippet:-1'
 ---
 
 <html lang="en" class="bg-white text-black dark:bg-white-reversed">
@@ -46,18 +61,23 @@ const jsonLdDocuments = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [
     <meta charset="utf-8" />
     <title>{pageTitle}</title>
     <meta name="description" content={description} />
-    <link rel="canonical" href={Astro.url.href} />
+    <link rel="canonical" href={canonicalUrl} />
+    <link rel="alternate" hreflang="en" href={selfUrl} />
+    <link rel="alternate" hreflang="x-default" href={selfUrl} />
+    <link rel="author" href={absoluteUrl('/about')} />
+    <link rel="me" href="https://github.com/anonrig" />
+    <link rel="me" href={xUrl} />
 
     <!-- Open Graph -->
-    <meta property="og:title" content={title ?? websiteTitle} />
+    <meta property="og:title" content={socialTitle} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content={article ? 'article' : 'website'} />
-    <meta property="og:url" content={Astro.url.href} />
+    <meta property="og:url" content={selfUrl} />
     <meta property="og:image" content={image} />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content={String(openGraphImage.width)} />
     <meta property="og:image:height" content={String(openGraphImage.height)} />
-    <meta property="og:image:alt" content={websiteTitle} />
+    <meta property="og:image:alt" content={socialImageAlt} />
     <meta property="og:locale" content="en_US" />
     <meta property="og:site_name" content={websiteTitle} />
 
@@ -69,23 +89,22 @@ const jsonLdDocuments = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [
 
     <!-- X (Twitter Cards protocol) -->
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content={`@${twitterUsername}`} />
     <meta name="twitter:creator" content={`@${twitterUsername}`} />
-    <meta name="twitter:title" content={title ?? websiteTitle} />
+    <meta name="twitter:title" content={socialTitle} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={image} />
-    <meta name="twitter:image:alt" content={websiteTitle} />
+    <meta name="twitter:image:alt" content={socialImageAlt} />
 
     <Font cssVariable="--font-mulish" preload />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="sitemap" href="/sitemap-index.xml" />
     <meta name="category" content="technology" />
+    <meta name="author" content={authorFullName} />
     <meta name="creator" content={authorFullName} />
     <meta name="publisher" content={authorFullName} />
-    <meta name="robots" content="index, follow" />
-    <meta
-      name="googlebot"
-      content="index, follow, max-video-preview:-1, max-image-preview:large, max-snippet:-1"
-    />
+    <meta name="robots" content={robots} />
+    <meta name="googlebot" content={googlebot} />
     <meta name="twitter:site:id" content={twitterId} />
     <meta name="twitter:creator:id" content={twitterId} />
     <meta name="twitter:image:type" content="image/png" />
@@ -129,7 +148,7 @@ const jsonLdDocuments = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [
       Skip to main content
     </a>
     <Header />
-    <main id="main-content" class="py-14">
+    <main id="main-content" class="py-14" itemprop="mainContentOfPage">
       <slot />
     </main>
     <CodeCopy />

--- a/src/lib/reading-time.ts
+++ b/src/lib/reading-time.ts
@@ -1,0 +1,15 @@
+export function countWords(body: string | undefined): number {
+  return (body ?? '').trim().split(/\s+/).filter(Boolean).length
+}
+
+export function readingTimeMinutes(words: number): number {
+  return Math.max(1, Math.round(words / 200))
+}
+
+export function readingTimeLabel(body: string | undefined): string {
+  return `${readingTimeMinutes(countWords(body))} min read`
+}
+
+export function readingTimeIso(body: string | undefined): string {
+  return `PT${readingTimeMinutes(countWords(body))}M`
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -3,34 +3,127 @@ import {
   authorFullName,
   authorJobTitle,
   githubImage,
+  openGraphImage,
   twitterUsername,
   websiteDescription,
   websiteTitle,
   websiteUrl,
 } from '@/lib/content'
+import { countWords, readingTimeIso } from '@/lib/reading-time'
 
 export type JsonLd = Record<string, unknown>
 
-const personId = `${websiteUrl}/#person`
-const websiteId = `${websiteUrl}/#website`
-const blogId = `${websiteUrl}/#blog`
+export interface BreadcrumbItem {
+  name: string
+  path: string
+}
+
+export const schemaIds = {
+  person: `${websiteUrl}/#person`,
+  website: `${websiteUrl}/#website`,
+  blog: `${websiteUrl}/#blog`,
+  webpage: `${websiteUrl}/#webpage`,
+} as const
+
+export type WebPageType = 'WebPage' | 'AboutPage' | 'ContactPage' | 'CollectionPage' | 'ProfilePage'
 
 export function absoluteUrl(path = '/'): string {
   if (path.startsWith('http://') || path.startsWith('https://')) {
     return path
   }
-  return new URL(path.startsWith('/') ? path : `/${path}`, websiteUrl).href
+  if (path === '/' || path === '') {
+    return websiteUrl
+  }
+  return `${websiteUrl}${path.startsWith('/') ? path : `/${path}`}`
+}
+
+export function pageCanonical(pathname: string, override?: string): string {
+  if (override) {
+    return override
+  }
+  const path = pathname.replace(/\/+$/, '') || '/'
+  return absoluteUrl(path)
+}
+
+export function imageObject(
+  url: string,
+  caption: string,
+  dimensions: { width: number; height: number } = openGraphImage,
+): JsonLd {
+  return {
+    '@type': 'ImageObject',
+    url,
+    contentUrl: url,
+    caption,
+    name: caption,
+    width: dimensions.width,
+    height: dimensions.height,
+    inLanguage: 'en-US',
+  }
+}
+
+export function isoDate(date: Date): string {
+  return date.toISOString().split('T')[0]
 }
 
 export function personJsonLd(): JsonLd {
   return {
     '@type': 'Person',
-    '@id': personId,
+    '@id': schemaIds.person,
     name: authorFullName,
+    givenName: 'Yagiz',
+    familyName: 'Nizipli',
+    alternateName: ['anonrig', 'Yağız Nizipli'],
     url: websiteUrl,
-    image: githubImage,
+    image: imageObject(githubImage, authorFullName, { width: 460, height: 460 }),
     jobTitle: authorJobTitle,
     description: websiteDescription,
+    knowsLanguage: ['en', 'tr'],
+    knowsAbout: [
+      'Node.js',
+      'V8',
+      'JavaScript',
+      'Software performance',
+      'URL parsing',
+      'C++',
+      'Rust',
+    ],
+    hasOccupation: {
+      '@type': 'Occupation',
+      name: authorJobTitle,
+      occupationalCategory: '15-1252.00',
+    },
+    memberOf: [
+      {
+        '@type': 'Organization',
+        name: 'Node.js Technical Steering Committee',
+        url: 'https://github.com/nodejs/TSC',
+      },
+      {
+        '@type': 'Organization',
+        name: 'V8',
+        url: 'https://v8.dev',
+      },
+      {
+        '@type': 'Organization',
+        name: 'Node.js Performance Team',
+        url: 'https://github.com/nodejs/performance',
+      },
+    ],
+    identifier: [
+      {
+        '@type': 'PropertyValue',
+        name: 'GitHub',
+        value: 'anonrig',
+        url: 'https://github.com/anonrig',
+      },
+      {
+        '@type': 'PropertyValue',
+        name: 'X',
+        value: twitterUsername,
+        url: `https://x.com/${twitterUsername}`,
+      },
+    ],
     sameAs: ['https://github.com/anonrig', `https://x.com/${twitterUsername}`],
   }
 }
@@ -38,42 +131,111 @@ export function personJsonLd(): JsonLd {
 export function websiteJsonLd(): JsonLd {
   return {
     '@type': 'WebSite',
-    '@id': websiteId,
+    '@id': schemaIds.website,
     url: websiteUrl,
     name: websiteTitle,
     description: websiteDescription,
     inLanguage: 'en-US',
-    publisher: { '@id': personId },
-    author: { '@id': personId },
+    publisher: { '@id': schemaIds.person },
+    author: { '@id': schemaIds.person },
+    copyrightHolder: { '@id': schemaIds.person },
+    potentialAction: {
+      '@type': 'SubscribeAction',
+      name: 'Subscribe to the newsletter',
+      target: absoluteUrl('/newsletter'),
+    },
+  }
+}
+
+export function breadcrumbsJsonLd(pageUrl: string, items: BreadcrumbItem[]): JsonLd {
+  return {
+    '@type': 'BreadcrumbList',
+    '@id': `${pageUrl}#breadcrumb`,
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: absoluteUrl(item.path),
+    })),
+  }
+}
+
+export function pageBreadcrumbs(name: string, path: string): BreadcrumbItem[] {
+  return [
+    { name: 'Home', path: '/' },
+    { name, path },
+  ]
+}
+
+export function blogBreadcrumbs(
+  post: CollectionEntry<'blog'>,
+  tag: CollectionEntry<'tags'>,
+): BreadcrumbItem[] {
+  return [
+    { name: 'Home', path: '/' },
+    { name: `#${tag.data.title}`, path: `/tag/${tag.id}` },
+    { name: post.data.title, path: `/${post.id}` },
+  ]
+}
+
+export function tagBreadcrumbs(tag: CollectionEntry<'tags'>): BreadcrumbItem[] {
+  return [
+    { name: 'Home', path: '/' },
+    { name: `#${tag.data.title}`, path: `/tag/${tag.id}` },
+  ]
+}
+
+function blogPostPreview(post: CollectionEntry<'blog'>): JsonLd {
+  const url = absoluteUrl(`/${post.id}`)
+  return {
+    '@type': 'BlogPosting',
+    '@id': `${url}#blogposting`,
+    headline: post.data.title,
+    url,
+    datePublished: isoDate(post.data.date),
+    description: post.data.description,
+    author: { '@id': schemaIds.person },
+    image: absoluteUrl(`/${post.id}/opengraph-image.png`),
   }
 }
 
 export function blogJsonLd(posts: CollectionEntry<'blog'>[]): JsonLd {
   return {
     '@type': 'Blog',
-    '@id': blogId,
+    '@id': schemaIds.blog,
     url: websiteUrl,
     name: websiteTitle,
     description: websiteDescription,
     inLanguage: 'en-US',
-    publisher: { '@id': personId },
-    author: { '@id': personId },
-    blogPost: posts.map((post) => ({
-      '@type': 'BlogPosting',
-      '@id': absoluteUrl(`/${post.id}`),
-      headline: post.data.title,
-      url: absoluteUrl(`/${post.id}`),
-      datePublished: post.data.date.toISOString().split('T')[0],
-      description: post.data.description,
-      author: { '@id': personId },
-    })),
+    publisher: { '@id': schemaIds.person },
+    author: { '@id': schemaIds.person },
+    blogPost: posts.map((post) => blogPostPreview(post)),
+    numberOfItems: posts.length,
   }
 }
 
 export function homeJsonLd(posts: CollectionEntry<'blog'>[]): JsonLd {
   return {
     '@context': 'https://schema.org',
-    '@graph': [personJsonLd(), websiteJsonLd(), blogJsonLd(posts)],
+    '@graph': [
+      personJsonLd(),
+      websiteJsonLd(),
+      blogJsonLd(posts),
+      {
+        '@type': 'WebPage',
+        '@id': schemaIds.webpage,
+        url: websiteUrl,
+        name: websiteTitle,
+        description: websiteDescription,
+        inLanguage: 'en-US',
+        isPartOf: { '@id': schemaIds.website },
+        about: { '@id': schemaIds.person },
+        mainEntity: { '@id': schemaIds.blog },
+        primaryImageOfPage: imageObject(`${websiteUrl}/opengraph-image.png`, websiteTitle),
+        author: { '@id': schemaIds.person },
+        publisher: { '@id': schemaIds.person },
+      },
+    ],
   }
 }
 
@@ -82,38 +244,58 @@ export function blogPostingJsonLd(
   tag: CollectionEntry<'tags'>,
 ): JsonLd {
   const url = absoluteUrl(`/${post.id}`)
-  const date = post.data.date.toISOString().split('T')[0]
-  const words = (post.body ?? '').trim().split(/\s+/).filter(Boolean).length
+  const date = isoDate(post.data.date)
+  const words = countWords(post.body)
+  const crumbs = blogBreadcrumbs(post, tag)
+  const image = imageObject(absoluteUrl(`/${post.id}/opengraph-image.png`), post.data.title)
 
   return {
     '@context': 'https://schema.org',
     '@graph': [
       personJsonLd(),
       websiteJsonLd(),
+      breadcrumbsJsonLd(url, crumbs),
       {
         '@type': 'BlogPosting',
         '@id': `${url}#blogposting`,
         mainEntityOfPage: {
           '@type': 'WebPage',
           '@id': url,
+          url,
+          name: post.data.title,
+          description: post.data.description,
+          isPartOf: { '@id': schemaIds.blog },
+          breadcrumb: { '@id': `${url}#breadcrumb` },
+          primaryImageOfPage: image,
         },
         headline: post.data.title,
         description: post.data.description,
         url,
-        image: absoluteUrl(`/${post.id}/opengraph-image.png`),
+        image,
+        thumbnailUrl: absoluteUrl(`/${post.id}/opengraph-image.png`),
         datePublished: date,
         dateModified: date,
         inLanguage: 'en-US',
-        author: { '@id': personId },
-        publisher: { '@id': personId },
+        author: { '@id': schemaIds.person },
+        publisher: { '@id': schemaIds.person },
+        copyrightHolder: { '@id': schemaIds.person },
+        copyrightYear: post.data.date.getUTCFullYear(),
         keywords: tag.data.title,
         articleSection: tag.data.title,
         wordCount: words,
-        isPartOf: { '@id': blogId },
+        timeRequired: readingTimeIso(post.body),
+        isAccessibleForFree: true,
+        isPartOf: { '@id': schemaIds.blog },
+        about: {
+          '@type': 'Thing',
+          name: tag.data.title,
+          url: absoluteUrl(`/tag/${tag.id}`),
+        },
         speakable: {
           '@type': 'SpeakableSpecification',
-          cssSelector: ['article h1', 'article.prose'],
+          cssSelector: ['article h1', '.prose'],
         },
+        ...(post.data.canonical_url ? { isBasedOn: post.data.canonical_url } : {}),
       },
     ],
   }
@@ -124,12 +306,14 @@ export function tagCollectionJsonLd(
   posts: CollectionEntry<'blog'>[],
 ): JsonLd {
   const url = absoluteUrl(`/tag/${tag.id}`)
+  const crumbs = tagBreadcrumbs(tag)
 
   return {
     '@context': 'https://schema.org',
     '@graph': [
       personJsonLd(),
       websiteJsonLd(),
+      breadcrumbsJsonLd(url, crumbs),
       {
         '@type': 'CollectionPage',
         '@id': url,
@@ -137,19 +321,25 @@ export function tagCollectionJsonLd(
         name: `#${tag.data.title}`,
         description: tag.data.description,
         inLanguage: 'en-US',
-        isPartOf: { '@id': blogId },
+        isPartOf: { '@id': schemaIds.blog },
+        breadcrumb: { '@id': `${url}#breadcrumb` },
         about: {
           '@type': 'Thing',
           name: tag.data.title,
+          url,
         },
+        author: { '@id': schemaIds.person },
+        publisher: { '@id': schemaIds.person },
         mainEntity: {
           '@type': 'ItemList',
           numberOfItems: posts.length,
+          itemListOrder: 'https://schema.org/ItemListOrderDescending',
           itemListElement: posts.map((post, index) => ({
             '@type': 'ListItem',
             position: index + 1,
             url: absoluteUrl(`/${post.id}`),
             name: post.data.title,
+            item: blogPostPreview(post),
           })),
         },
       },
@@ -157,19 +347,39 @@ export function tagCollectionJsonLd(
   }
 }
 
+export function scholarlyArticleJsonLd(): JsonLd {
+  return {
+    '@type': 'ScholarlyArticle',
+    '@id': 'https://doi.org/10.1002/spe.3296',
+    name: 'Parsing Millions of URLs per Second',
+    url: 'https://onlinelibrary.wiley.com/doi/full/10.1002/spe.3296',
+    identifier: 'https://doi.org/10.1002/spe.3296',
+    author: [{ '@id': schemaIds.person }, { '@type': 'Person', name: 'Daniel Lemire' }],
+    datePublished: '2023-03-07',
+  }
+}
+
 export function webPageJsonLd(options: {
   path: string
   title: string
   description: string
-  type?: 'WebPage' | 'AboutPage' | 'ContactPage' | 'CollectionPage'
+  type?: WebPageType | WebPageType[]
+  breadcrumbs?: BreadcrumbItem[]
+  image?: string
+  hasPart?: Array<{ name: string; fragment: string }>
+  mainEntity?: JsonLd
+  potentialAction?: JsonLd
 }): JsonLd {
   const url = absoluteUrl(options.path)
+  const crumbs = options.breadcrumbs ?? pageBreadcrumbs(options.title, options.path)
+  const image = imageObject(options.image ?? `${websiteUrl}/opengraph-image.png`, options.title)
 
   return {
     '@context': 'https://schema.org',
     '@graph': [
       personJsonLd(),
       websiteJsonLd(),
+      breadcrumbsJsonLd(url, crumbs),
       {
         '@type': options.type ?? 'WebPage',
         '@id': url,
@@ -177,11 +387,96 @@ export function webPageJsonLd(options: {
         name: options.title,
         description: options.description,
         inLanguage: 'en-US',
-        isPartOf: { '@id': websiteId },
-        about: { '@id': personId },
-        author: { '@id': personId },
-        publisher: { '@id': personId },
+        isPartOf: { '@id': schemaIds.website },
+        about: { '@id': schemaIds.person },
+        author: { '@id': schemaIds.person },
+        publisher: { '@id': schemaIds.person },
+        breadcrumb: { '@id': `${url}#breadcrumb` },
+        primaryImageOfPage: image,
+        ...(options.mainEntity ? { mainEntity: options.mainEntity } : {}),
+        ...(options.potentialAction ? { potentialAction: options.potentialAction } : {}),
+        ...(options.hasPart
+          ? {
+              hasPart: options.hasPart.map((part) => ({
+                '@type': 'WebPageElement',
+                name: part.name,
+                url: `${url}#${part.fragment}`,
+              })),
+            }
+          : {}),
       },
     ],
   }
+}
+
+export function aboutPageJsonLd(title: string, description: string): JsonLd {
+  const graph = webPageJsonLd({
+    path: '/about',
+    title,
+    description,
+    type: ['ProfilePage', 'AboutPage'],
+    mainEntity: { '@id': schemaIds.person },
+    hasPart: [
+      { name: 'Who is Yagiz Nizipli?', fragment: 'who-is-yagiz-nizipli' },
+      { name: 'Memberships', fragment: 'memberships' },
+      { name: 'Academic Papers', fragment: 'academic-papers' },
+      { name: 'Links', fragment: 'links' },
+    ],
+  })
+
+  const nodes = graph['@graph']
+  if (Array.isArray(nodes)) {
+    nodes.push(scholarlyArticleJsonLd())
+  }
+  return graph
+}
+
+export function contactPageJsonLd(title: string, description: string): JsonLd {
+  return webPageJsonLd({
+    path: '/contact',
+    title,
+    description,
+    type: 'ContactPage',
+    mainEntity: {
+      '@type': 'ContactPoint',
+      contactType: 'author',
+      url: absoluteUrl('/contact'),
+      availableLanguage: ['English', 'Turkish'],
+    },
+  })
+}
+
+export function newsletterPageJsonLd(title: string, description: string): JsonLd {
+  return webPageJsonLd({
+    path: '/newsletter',
+    title,
+    description,
+    potentialAction: {
+      '@type': 'SubscribeAction',
+      name: 'Subscribe to the newsletter',
+      target: {
+        '@type': 'EntryPoint',
+        urlTemplate: absoluteUrl('/newsletter'),
+        actionPlatform: [
+          'https://schema.org/DesktopWebPlatform',
+          'https://schema.org/MobileWebPlatform',
+        ],
+      },
+    },
+  })
+}
+
+export function pressPageJsonLd(title: string, description: string): JsonLd {
+  return webPageJsonLd({
+    path: '/press',
+    title,
+    description,
+    type: 'CollectionPage',
+    hasPart: [
+      { name: 'Articles', fragment: 'articles' },
+      { name: 'Printed Media', fragment: 'printed-media' },
+      { name: 'Presentations & Podcasts', fragment: 'presentations--podcasts' },
+      { name: 'Contributions', fragment: 'contributions' },
+    ],
+  })
 }

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,7 +3,7 @@ import { Stethoscope } from '@lucide/astro'
 import Container from '@/components/ui/Container.astro'
 import Layout from '@/layouts/Layout.astro'
 ---
-<Layout title="Page not found">
+<Layout title="Page not found" robots="noindex, follow">
   <Container class="flex h-[calc(100vh-320px)] items-center justify-center mx-auto">
     <div class="flex flex-col items-center space-y-4">
       <Stethoscope size={24} aria-hidden="true" class="text-black dark:text-white" />

--- a/src/pages/[id]/index.astro
+++ b/src/pages/[id]/index.astro
@@ -5,6 +5,7 @@ import type { GetStaticPaths } from 'astro'
 import BlogFooter from '@/components/BlogFooter.astro'
 import BlogRow from '@/components/BlogRow.astro'
 import BlogStickyHeader from '@/components/BlogStickyHeader.astro'
+import Breadcrumbs from '@/components/Breadcrumbs.astro'
 import MarkdownLink from '@/components/MarkdownLink.astro'
 import { components } from '@/components/mdx'
 import Container from '@/components/ui/Container.astro'
@@ -13,7 +14,8 @@ import Heading from '@/components/ui/Heading.astro'
 import Prose from '@/components/ui/Prose.astro'
 import Layout from '@/layouts/Layout.astro'
 import { authorFullName, websiteUrl } from '@/lib/content'
-import { blogPostingJsonLd } from '@/lib/schema'
+import { countWords, readingTimeLabel } from '@/lib/reading-time'
+import { absoluteUrl, blogBreadcrumbs, blogPostingJsonLd, isoDate } from '@/lib/schema'
 
 interface Props {
   post: CollectionEntry<'blog'>
@@ -35,8 +37,8 @@ const tag = await getEntry(post.data.tag.collection, post.data.tag.id)
 if (!tag) {
   throw new Error('Tag not found')
 }
-const words = (post.body ?? '').trim().split(/\s+/).length
-const minute_to_read = `${Math.max(1, Math.round(words / 200))} min read`
+const words = countWords(post.body)
+const minute_to_read = readingTimeLabel(post.body)
 
 const posts = await getCollection('blog', ({ data }) => data.status === 'published')
 posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
@@ -44,16 +46,20 @@ const index = posts.findIndex((p) => p.id === post.id)
 const suggestions = [posts.at(index - 2), posts.at(index - 1)].filter(
   Boolean,
 ) as CollectionEntry<'blog'>[]
-const publishedTime = post.data.date.toISOString().split('T')[0]
+const publishedTime = isoDate(post.data.date)
 const markdownUrl = `${websiteUrl}/${post.id}.md`
+const url = absoluteUrl(`/${post.id}`)
+const crumbs = blogBreadcrumbs(post, tag)
 ---
 
 <Layout
   title={post.data.title}
   description={post.data.description}
   image={`${Astro.url.origin}/${post.id}/opengraph-image.png`}
+  imageAlt={post.data.title}
   markdownUrl={markdownUrl}
   jsonLd={blogPostingJsonLd(post, tag)}
+  canonical={post.data.canonical_url}
   article={{
     authors: [authorFullName],
     publishedTime,
@@ -61,13 +67,25 @@ const markdownUrl = `${websiteUrl}/${post.id}.md`
     tags: [tag.data.title],
   }}
 >
-  <article>
+  <article
+    itemscope
+    itemtype="https://schema.org/BlogPosting"
+    itemid={`${url}#blogposting`}
+  >
+    <link itemprop="url" href={url} />
+    <meta itemprop="description" content={post.data.description} />
+    <meta itemprop="inLanguage" content="en-US" />
+    <meta itemprop="wordCount" content={String(words)} />
+    <meta itemprop="isAccessibleForFree" content="true" />
     <header class="mb-6 grid grid-cols-canvas text-center">
+      <div class="col-main mb-4">
+        <Breadcrumbs items={crumbs} />
+      </div>
       <div
         class="col-main mb-4 text-xs font-extrabold uppercase text-slate-500"
       >
         <span>
-          <time datetime={post.data.date.toISOString()}>
+          <time datetime={post.data.date.toISOString()} itemprop="datePublished">
             {
               new Intl.DateTimeFormat("en-US", {
                 month: "short",
@@ -76,6 +94,7 @@ const markdownUrl = `${websiteUrl}/${post.id}.md`
               }).format(post.data.date)
             }
           </time>
+          <meta itemprop="dateModified" content={post.data.date.toISOString()} />
         </span>
         <span class="before:px-2 before:font-serif before:leading-[1] before:content-['·']">
           {minute_to_read}
@@ -84,6 +103,7 @@ const markdownUrl = `${websiteUrl}/${post.id}.md`
           <a
             href={`/tag/${post.data.tag.id}`}
             class="text-orange-400 hover:text-orange-300"
+            itemprop="articleSection"
           >
             {tag.data.title}
           </a>
@@ -93,7 +113,7 @@ const markdownUrl = `${websiteUrl}/${post.id}.md`
         <MarkdownLink href={markdownUrl} />
       </div>
 
-      <Heading>{post.data.title}</Heading>
+      <Heading itemprop="headline">{post.data.title}</Heading>
 
       {
         post.data.image && (
@@ -101,12 +121,13 @@ const markdownUrl = `${websiteUrl}/${post.id}.md`
             alt={post.data.image.alt}
             src={post.data.image.src}
             caption={post.data.title}
+            itemprop="image"
           />
         )
       }
     </header>
     <BlogStickyHeader {post} />
-    <Prose>
+    <Prose as="div" itemprop="articleBody">
       <Content {components} />
     </Prose>
     <BlogFooter {index} />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,8 +3,8 @@ import { getEntry } from 'astro:content'
 import MarkdownLink from '@/components/MarkdownLink.astro'
 import Page from '@/components/Page.astro'
 import Layout from '@/layouts/Layout.astro'
-import { websiteUrl } from '@/lib/content'
-import { webPageJsonLd } from '@/lib/schema'
+import { authorFullName, websiteUrl } from '@/lib/content'
+import { aboutPageJsonLd, absoluteUrl, pageBreadcrumbs, schemaIds } from '@/lib/schema'
 
 const page = await getEntry('pages', 'about')
 if (!page) {
@@ -12,19 +12,30 @@ if (!page) {
 }
 
 const markdownUrl = `${websiteUrl}/about.md`
+const breadcrumbs = pageBreadcrumbs(page.data.title, '/about')
 ---
 <Layout
   title={page.data.title}
   description={page.data.description}
   markdownUrl={markdownUrl}
-  jsonLd={webPageJsonLd({
-    path: '/about',
-    title: page.data.title,
-    description: page.data.description,
-    type: 'AboutPage',
-  })}
+  jsonLd={aboutPageJsonLd(page.data.title, page.data.description)}
 >
-  <Page {page} />
+  <Page
+    {page}
+    itemtype="https://schema.org/ProfilePage"
+    itemid={absoluteUrl('/about')}
+    breadcrumbs={breadcrumbs}
+  >
+    <div
+      itemprop="mainEntity"
+      itemscope
+      itemtype="https://schema.org/Person"
+      itemid={schemaIds.person}
+    >
+      <meta itemprop="name" content={authorFullName} />
+      <link itemprop="url" href={websiteUrl} />
+    </div>
+  </Page>
   <div class="mx-auto mt-8 max-w-[calc(750px+8vw)] px-[4vw] text-center">
     <MarkdownLink href={markdownUrl} />
   </div>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -5,7 +5,7 @@ import MarkdownLink from '@/components/MarkdownLink.astro'
 import Page from '@/components/Page.astro'
 import Layout from '@/layouts/Layout.astro'
 import { websiteUrl } from '@/lib/content'
-import { webPageJsonLd } from '@/lib/schema'
+import { absoluteUrl, contactPageJsonLd, pageBreadcrumbs } from '@/lib/schema'
 
 const page = await getEntry('pages', 'contact')
 if (!page) {
@@ -13,20 +13,21 @@ if (!page) {
 }
 
 const markdownUrl = `${websiteUrl}/contact.md`
+const breadcrumbs = pageBreadcrumbs(page.data.title, '/contact')
 ---
 
 <Layout
   title={page.data.title}
   description={page.data.description}
   markdownUrl={markdownUrl}
-  jsonLd={webPageJsonLd({
-    path: '/contact',
-    title: page.data.title,
-    description: page.data.description,
-    type: 'ContactPage',
-  })}
+  jsonLd={contactPageJsonLd(page.data.title, page.data.description)}
 >
-  <Page {page}>
+  <Page
+    {page}
+    itemtype="https://schema.org/ContactPage"
+    itemid={absoluteUrl('/contact')}
+    breadcrumbs={breadcrumbs}
+  >
     <ContactForm />
   </Page>
   <div class="mx-auto mt-8 max-w-[calc(750px+8vw)] px-[4vw] text-center">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,8 +7,8 @@ import MarkdownLink from '@/components/MarkdownLink.astro'
 import SubscribeButton from '@/components/SubscribeButton.astro'
 import Container from '@/components/ui/Container.astro'
 import Layout from '@/layouts/Layout.astro'
-import { websiteUrl } from '@/lib/content'
-import { homeJsonLd } from '@/lib/schema'
+import { websiteDescription, websiteTitle, websiteUrl } from '@/lib/content'
+import { homeJsonLd, schemaIds } from '@/lib/schema'
 
 const posts = await getCollection('blog', ({ data }) => data.status === 'published')
 posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
@@ -26,8 +26,9 @@ const markdownUrl = `${websiteUrl}/index.md`
 ---
 
 <Layout markdownUrl={markdownUrl} jsonLd={homeJsonLd(posts)}>
+  <div itemscope itemtype="https://schema.org/WebPage" itemid={schemaIds.webpage}>
     <div class="-mt-8 mx-auto mb-4 flex max-w-lg flex-col items-center text-center">
-      <div class="relative mb-8">
+      <div class="relative mb-8" itemscope itemtype="https://schema.org/ImageObject">
         <Image
           alt="Engineering with Yagiz"
           src={familyImg}
@@ -35,9 +36,12 @@ const markdownUrl = `${websiteUrl}/index.md`
           height={150}
           loading="eager"
           class="rounded-full"
+          itemprop="contentUrl"
         />
+        <meta itemprop="caption" content="Engineering with Yagiz" />
       </div>
-      <h1 class="sr-only">Yagiz Nizipli's website</h1>
+      <h1 class="sr-only" itemprop="name">{websiteTitle}</h1>
+      <meta itemprop="description" content={websiteDescription} />
       <div class="text-lg dark:text-zinc-200">
         Here's a collection of posts about my thoughts, stories, ideas and
         experiences as a human, and an engineer working with different
@@ -47,16 +51,26 @@ const markdownUrl = `${websiteUrl}/index.md`
       <SubscribeButton />
       <MarkdownLink href={markdownUrl} class="mt-4" />
     </div>
-  <div class="pt-8">
-    {years.map((year) => (
-      <Container size="tight" class="mx-auto px-[4vw] mb-12">
-        <h2 class="text-sm font-extrabold text-neutral-500 dark:text-neutral-400 mb-2">
-          {year}
-        </h2>
-        <div class="divide-y divide-slate-200 dark:divide-neutral-700">
-          {postsByYear.get(year)!.map((post) => <BlogRow {post} />)}
-        </div>
-      </Container>
-    ))}
+    <div
+      class="pt-8"
+      itemprop="mainEntity"
+      itemscope
+      itemtype="https://schema.org/Blog"
+      itemid={schemaIds.blog}
+    >
+      <meta itemprop="name" content={websiteTitle} />
+      <meta itemprop="description" content={websiteDescription} />
+      <link itemprop="url" href={websiteUrl} />
+      {years.map((year) => (
+        <Container size="tight" class="mx-auto px-[4vw] mb-12">
+          <h2 class="text-sm font-extrabold text-neutral-500 dark:text-neutral-400 mb-2">
+            {year}
+          </h2>
+          <div class="divide-y divide-slate-200 dark:divide-neutral-700">
+            {postsByYear.get(year)!.map((post) => <BlogRow {post} itemprop="blogPost" />)}
+          </div>
+        </Container>
+      ))}
+    </div>
   </div>
 </Layout>

--- a/src/pages/newsletter.astro
+++ b/src/pages/newsletter.astro
@@ -5,7 +5,7 @@ import NewsletterForm from '@/components/NewsletterForm.astro'
 import Page from '@/components/Page.astro'
 import Layout from '@/layouts/Layout.astro'
 import { websiteUrl } from '@/lib/content'
-import { webPageJsonLd } from '@/lib/schema'
+import { absoluteUrl, newsletterPageJsonLd, pageBreadcrumbs } from '@/lib/schema'
 
 const page = await getEntry('pages', 'newsletter')
 if (!page) {
@@ -13,19 +13,21 @@ if (!page) {
 }
 
 const markdownUrl = `${websiteUrl}/newsletter.md`
+const breadcrumbs = pageBreadcrumbs(page.data.title, '/newsletter')
 ---
 
 <Layout
   title={page.data.title}
   description={page.data.description}
   markdownUrl={markdownUrl}
-  jsonLd={webPageJsonLd({
-    path: '/newsletter',
-    title: page.data.title,
-    description: page.data.description,
-  })}
+  jsonLd={newsletterPageJsonLd(page.data.title, page.data.description)}
 >
-  <Page {page}>
+  <Page
+    {page}
+    itemtype="https://schema.org/WebPage"
+    itemid={absoluteUrl('/newsletter')}
+    breadcrumbs={breadcrumbs}
+  >
     <NewsletterForm />
   </Page>
   <div class="mx-auto mt-8 max-w-[calc(750px+8vw)] px-[4vw] text-center">

--- a/src/pages/press.astro
+++ b/src/pages/press.astro
@@ -4,7 +4,7 @@ import MarkdownLink from '@/components/MarkdownLink.astro'
 import Page from '@/components/Page.astro'
 import Layout from '@/layouts/Layout.astro'
 import { websiteUrl } from '@/lib/content'
-import { webPageJsonLd } from '@/lib/schema'
+import { absoluteUrl, pageBreadcrumbs, pressPageJsonLd } from '@/lib/schema'
 
 const page = await getEntry('pages', 'press')
 
@@ -13,19 +13,20 @@ if (!page) {
 }
 
 const markdownUrl = `${websiteUrl}/press.md`
+const breadcrumbs = pageBreadcrumbs(page.data.title, '/press')
 ---
 <Layout
   title={page.data.title}
   description={page.data.description}
   markdownUrl={markdownUrl}
-  jsonLd={webPageJsonLd({
-    path: '/press',
-    title: page.data.title,
-    description: page.data.description,
-    type: 'CollectionPage',
-  })}
+  jsonLd={pressPageJsonLd(page.data.title, page.data.description)}
 >
-  <Page {page} />
+  <Page
+    {page}
+    itemtype="https://schema.org/CollectionPage"
+    itemid={absoluteUrl('/press')}
+    breadcrumbs={breadcrumbs}
+  />
   <div class="mx-auto mt-8 max-w-[calc(750px+8vw)] px-[4vw] text-center">
     <MarkdownLink href={markdownUrl} />
   </div>

--- a/src/pages/tag/[id].astro
+++ b/src/pages/tag/[id].astro
@@ -3,11 +3,12 @@ import type { CollectionEntry } from 'astro:content'
 import { getCollection } from 'astro:content'
 import type { GetStaticPaths } from 'astro'
 import BlogRow from '@/components/BlogRow.astro'
+import Breadcrumbs from '@/components/Breadcrumbs.astro'
 import MarkdownLink from '@/components/MarkdownLink.astro'
 import Container from '@/components/ui/Container.astro'
 import Layout from '@/layouts/Layout.astro'
 import { websiteUrl } from '@/lib/content'
-import { tagCollectionJsonLd } from '@/lib/schema'
+import { absoluteUrl, tagBreadcrumbs, tagCollectionJsonLd } from '@/lib/schema'
 
 interface Props {
   tag: CollectionEntry<'tags'>
@@ -29,6 +30,8 @@ const posts = await getCollection(
 )
 posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
 const markdownUrl = `${websiteUrl}/tag/${tag.id}.md`
+const url = absoluteUrl(`/tag/${tag.id}`)
+const crumbs = tagBreadcrumbs(tag)
 ---
 
 <Layout
@@ -37,11 +40,13 @@ const markdownUrl = `${websiteUrl}/tag/${tag.id}.md`
   markdownUrl={markdownUrl}
   jsonLd={tagCollectionJsonLd(tag, posts)}
 >
-  <section>
+  <section itemscope itemtype="https://schema.org/CollectionPage" itemid={url}>
+    <link itemprop="url" href={url} />
     <Container size="tight" class="mx-auto -mt-6 flex flex-col gap-8 px-[4vw] text-center">
-      <h1 class="text-2xl font-extrabold text-orange-400">#{tag.data.title}</h1>
+      <Breadcrumbs items={crumbs} />
+      <h1 class="text-2xl font-extrabold text-orange-400" itemprop="name">#{tag.data.title}</h1>
 
-      <div class="leading-6 dark:text-white">{tag.data.description}</div>
+      <div class="leading-6 dark:text-white" itemprop="description">{tag.data.description}</div>
 
       <div>
         <span class="mr-2 mt-2 font-bold dark:text-white">More:</span>
@@ -60,12 +65,25 @@ const markdownUrl = `${websiteUrl}/tag/${tag.id}.md`
       <MarkdownLink href={markdownUrl} />
     </Container>
 
-    <div class="py-14">
+    <div
+      class="py-14"
+      itemprop="mainEntity"
+      itemscope
+      itemtype="https://schema.org/ItemList"
+    >
+      <meta itemprop="numberOfItems" content={String(posts.length)} />
       <Container
         size="tight"
         class="mx-auto divide-y divide-slate-200 px-[4vw] dark:divide-neutral-700"
       >
-        {posts.map((post) => <BlogRow {post} />)}
+        {
+          posts.map((post, index) => (
+            <div itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+              <meta itemprop="position" content={String(index + 1)} />
+              <BlogRow {post} itemprop="item" />
+            </div>
+          ))
+        }
       </Container>
     </div>
   </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
---
type: feature
intent: Improve Google-facing structured data and on-page SEO across every HTML page
app-source-changed: true
constraints: typescript@6, markdown-processor: unified
verify:
  - node --run lint
  - node --run build
preview: https://cursor-improve-seo-jsonld-b6e5-yagiz.nizipli.workers.dev
---

## Summary

Structured data already existed (`src/lib/schema.ts`) but it was thin, there was no microdata, and a few real SEO bugs were hurting more than missing schema.

This pass investigates every HTML page and:

- Expands JSON-LD graphs with `BreadcrumbList`, richer `Person` / `WebSite`, home `WebPage`, blog `ImageObject` + `timeRequired`, about `ProfilePage` + scholarly article, contact `ContactPoint`, newsletter `SubscribeAction`, and press section `hasPart` links
- Adds matching visible microdata (`BlogPosting`, `CollectionPage`, `ProfilePage`, `ImageObject`, `ItemList`, nav `SiteNavigationElement`) so Google can associate on-page markup with the JSON-LD `@id`s
- Renders visible breadcrumbs (required for Breadcrumb rich results)
- Uses `https://www.yagiz.co` + path for canonicals instead of `Astro.url.href`
- Honors `canonical_url` on syndicated posts (Snyk / Sentry) and sets `isBasedOn`
- Marks `/404` `noindex, follow`
- Fixes the contact meta description (it was a copy of press) and the newsletter "Easest" typo
- Adds About + Newsletter to the footer for internal linking
- Stops stamping every sitemap URL with the build clock
- Disallows `/api/` in `robots.txt`

## Non-goals

- No fake `SearchAction` / sitelinks search box (there is no site search)
- No HowTo / FAQ spam generated from blog posts
- No per-press-item ItemList (would duplicate the MDX list and drift)
- No ranking claims — structured data helps rich results and entity understanding, not a guaranteed position bump
- Worker Accept negotiation and markdown endpoints are unchanged except inherited description text

## Test plan

- [x] `node --run lint`
- [x] `node --run build`
- [x] Home JSON-LD `@graph` includes `Person`, `WebSite`, `Blog`, `WebPage`
- [x] Post JSON-LD includes `BlogPosting` + `BreadcrumbList`; HTML has visible breadcrumbs and `itemtype="https://schema.org/BlogPosting"`
- [x] About JSON-LD is `ProfilePage` + `AboutPage` and includes the SPE scholarly article
- [x] Contact / press / newsletter / tag pages emit typed JSON-LD + breadcrumbs
- [x] Syndicated post `using-insecure-npm-defaults` has `rel=canonical` → Snyk and `isBasedOn` in JSON-LD
- [x] `404` has `robots` / `googlebot` `noindex, follow`
- [x] Contact meta description is about contacting Yagiz, not press
- [x] Markdown / Worker / sitemap (local `wrangler dev` on :8787):
  - [x] `GET /llms.txt` → `200 text/plain`
  - [x] `GET /llms-full.txt` → `200 text/plain` (full post dump)
  - [x] `GET /contact.md` → YAML frontmatter with the new description
  - [x] `Accept: text/markdown` on `/about` → `Content-Type: text/markdown` + `Vary: Accept`
  - [x] HTML response has `Link: </about.md>; rel="alternate"; type="text/markdown"`
  - [x] `Accept: application/pdf` → `406`
  - [x] sitemap lists HTML only (no `.md` / `llms*.txt`)
- [x] Cloudflare preview `https://cursor-improve-seo-jsonld-b6e5-yagiz.nizipli.workers.dev/about` serves the new `@graph` (`ProfilePage` + `AboutPage` + `ScholarlyArticle` + `BreadcrumbList`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

