### PR TITLE
Improve ranking signals beyond structured data

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -17,10 +17,13 @@ import {
   transformerInlineStylesToClasses,
   transformerMetaTitle,
 } from './src/lib/shiki-transformers.ts'
+import { loadSitemapLastmods } from './src/lib/sitemap-dates.ts'
 
 function isMarkdownOrLlmsAsset(page: string): boolean {
   return page.endsWith('.md') || page.endsWith('/llms.txt') || page.endsWith('/llms-full.txt')
 }
+
+const sitemapLastmods = loadSitemapLastmods()
 
 const pageCache = { maxAge: 3600, swr: 86400, tags: ['page'] }
 
@@ -114,8 +117,12 @@ export default defineConfig({
     mdx(),
     sitemap({
       // Markdown / llms endpoints are for agents; keep them out of the HTML sitemap.
-      // Do not stamp every URL with the build clock — Google treats that lastmod as noise.
+      // lastmod comes from each post's frontmatter date, not the build clock.
       filter: (page) => !isMarkdownOrLlmsAsset(page),
+      serialize(item) {
+        const lastmod = sitemapLastmods.get(item.url.replace(/\/+$/, ''))
+        return lastmod ? { ...item, lastmod } : item
+      },
     }),
   ],
   vite: {

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,8 @@
+/*.md
+  X-Robots-Tag: noindex, nofollow
+
+/llms.txt
+  X-Robots-Tag: noindex, nofollow
+
+/llms-full.txt
+  X-Robots-Tag: noindex, nofollow

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,39 @@
+---
+interface Heading {
+  depth: number
+  slug: string
+  text: string
+}
+
+interface Props {
+  headings: Heading[]
+}
+
+const headings = Astro.props.headings.filter(
+  (heading) => heading.depth === 2 || heading.depth === 3,
+)
+---
+
+{
+  headings.length >= 3 && (
+    <nav aria-label="Table of contents" class="mb-10 grid grid-cols-canvas">
+      <div class="col-main rounded-md border border-slate-200 px-4 py-3 text-left dark:border-neutral-700">
+        <p class="mb-2 text-xs font-extrabold uppercase tracking-wide text-slate-500">
+          On this page
+        </p>
+        <ol class="space-y-1 text-sm">
+          {headings.map((heading) => (
+            <li class:list={[heading.depth === 3 && 'pl-4']}>
+              <a
+                href={`#${heading.slug}`}
+                class="font-bold text-orange-400 hover:text-orange-300"
+              >
+                {heading.text}
+              </a>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </nav>
+  )
+}

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,10 +1,11 @@
 ---
 import type { Item } from './Footer.astro'
 
-const headerItems: Item[] = [
+const headerItems: Array<Item & { hideOnNarrow?: boolean }> = [
   { title: 'Home', href: '/' },
   { title: 'About', href: '/about' },
   { title: 'Press', href: '/press' },
+  { title: 'Newsletter', href: '/newsletter', hideOnNarrow: true },
   { title: 'Contact', href: '/contact' },
 ]
 
@@ -36,7 +37,10 @@ const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.s
         <a
           href={item.href}
           aria-current={isActive(item.href) ? 'page' : undefined}
-          class="mx-1 md:mx-4 text-sm font-bold text-slate-800 hover:text-slate-600 dark:text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 rounded"
+          class:list={[
+            'mx-1 rounded text-sm font-bold text-slate-800 hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 dark:text-zinc-200 md:mx-4',
+            item.hideOnNarrow && 'hidden sm:inline',
+          ]}
         >
           {item.title}
         </a>

--- a/src/components/ui/Figure.astro
+++ b/src/components/ui/Figure.astro
@@ -22,6 +22,7 @@ const props = Astro.props
     alt={props.alt}
     width={920}
     loading="eager"
+    fetchpriority="high"
     class="duration-300 ease-in-out bg-gray-100 dark:bg-gray-900 aspect-[2/1] w-full object-cover object-center"
     itemprop="contentUrl"
   />

--- a/src/content/blog/using-insecure-npm-defaults.mdx
+++ b/src/content/blog/using-insecure-npm-defaults.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Using insecure npm package manager defaults to steal your macOS keyboard shortcuts'
 description: >-
-  Node Package Manager (npm) provides a set of scripts for developers and package maintainers to maintain the life cycle events of a package.
+  How insecure npm lifecycle-script defaults can steal macOS keyboard shortcuts, and how to lock them down.
 date: 2023-06-28
 tag: security
 status: published

--- a/src/content/pages/about.mdx
+++ b/src/content/pages/about.mdx
@@ -1,7 +1,8 @@
 ---
 title: About
 description: >-
-  Node.js core member and OpenJS Foundation Cross Project Council regular member
+  Yagiz Nizipli is a V8 committer and Node.js Technical Steering Committee
+  member. He writes about software performance, URL parsing, and Node.js internals.
 image:
   src: about.jpeg
   caption: Yagiz Nizipli

--- a/src/content/tags/algorithms.mdx
+++ b/src/content/tags/algorithms.mdx
@@ -1,5 +1,5 @@
 ---
 title: Algorithms
 description: >-
-  Algorithms related articles I've written in the past
+  Notes on algorithms and data structures used to make parsers, boards, and hot paths faster.
 ---

--- a/src/content/tags/coding.mdx
+++ b/src/content/tags/coding.mdx
@@ -1,5 +1,5 @@
 ---
 title: Coding
 description: >-
-  Coding related articles I've written in the past
+  Practical notes on writing, testing, and shipping software.
 ---

--- a/src/content/tags/database.mdx
+++ b/src/content/tags/database.mdx
@@ -1,5 +1,5 @@
 ---
 title: Database
 description: >-
-  Database related articles I've written in the past
+  Notes on PostgreSQL, indexes, and making database queries faster.
 ---

--- a/src/content/tags/experimental.mdx
+++ b/src/content/tags/experimental.mdx
@@ -1,5 +1,5 @@
 ---
 title: Experimental
 description: >-
-  Experimental articles I've been writing on the side.
+  Side experiments and in-progress ideas from Yagiz Nizipli.
 ---

--- a/src/content/tags/performance.mdx
+++ b/src/content/tags/performance.mdx
@@ -1,5 +1,5 @@
 ---
 title: Performance
 description: >-
-  Articles involving algorithms, performance and optimizations I've worked on.
+  Articles on Node.js, C++, and V8 performance — URL parsing, loaders, and the optimizations behind them.
 ---

--- a/src/content/tags/security.mdx
+++ b/src/content/tags/security.mdx
@@ -1,5 +1,5 @@
 ---
 title: Security
 description: >-
-  Posts related to information and application security written by Yagiz Nizipli
+  Posts on application security: npm defaults, timing attacks, and locking down web apps.
 ---

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,7 +22,7 @@ interface Props {
   imageAlt?: string
   markdownUrl?: string
   jsonLd?: JsonLd | JsonLd[]
-  canonical?: string
+  canonical?: string | false
   robots?: string
   article?: {
     authors?: string[]
@@ -44,10 +44,10 @@ const {
   article,
 } = Astro.props
 
-const pageTitle = title ? `${title} - ${websiteTitle}` : websiteTitle
+const pageTitle = title ? `${title} · ${authorFullName}` : websiteTitle
 const jsonLdDocuments = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : []
 const selfUrl = pageCanonical(Astro.url.pathname)
-const canonicalUrl = pageCanonical(Astro.url.pathname, canonical)
+const canonicalUrl = canonical === false ? undefined : pageCanonical(Astro.url.pathname, canonical)
 const socialTitle = title ?? websiteTitle
 const socialImageAlt = imageAlt ?? socialTitle
 const noindex = robots.includes('noindex')
@@ -61,9 +61,15 @@ const googlebot = noindex
     <meta charset="utf-8" />
     <title>{pageTitle}</title>
     <meta name="description" content={description} />
-    <link rel="canonical" href={canonicalUrl} />
-    <link rel="alternate" hreflang="en" href={selfUrl} />
-    <link rel="alternate" hreflang="x-default" href={selfUrl} />
+    {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+    {
+      canonical !== false && (
+        <>
+          <link rel="alternate" hreflang="en" href={selfUrl} />
+          <link rel="alternate" hreflang="x-default" href={selfUrl} />
+        </>
+      )
+    }
     <link rel="author" href={absoluteUrl('/about')} />
     <link rel="me" href="https://github.com/anonrig" />
     <link rel="me" href={xUrl} />

--- a/src/lib/accept.ts
+++ b/src/lib/accept.ts
@@ -108,6 +108,15 @@ export function isImmutableAsset(pathname: string): boolean {
   return pathname.startsWith('/_astro/') || IMMUTABLE_ASSET.test(pathname)
 }
 
+export function isAgentOnlyPath(pathname: string): boolean {
+  return (
+    pathname.endsWith('.md') ||
+    pathname === '/llms.txt' ||
+    pathname === '/llms-full.txt' ||
+    pathname.endsWith('/llms.txt')
+  )
+}
+
 /** Paths that should skip HTML↔markdown negotiation. */
 export function shouldSkipNegotiation(pathname: string): boolean {
   return (

--- a/src/lib/related-posts.ts
+++ b/src/lib/related-posts.ts
@@ -1,0 +1,19 @@
+import type { CollectionEntry } from 'astro:content'
+
+export function relatedPosts(
+  current: CollectionEntry<'blog'>,
+  all: CollectionEntry<'blog'>[],
+  limit = 3,
+): CollectionEntry<'blog'>[] {
+  const sameTag = all.filter(
+    (post) => post.id !== current.id && post.data.tag.id === current.data.tag.id,
+  )
+  if (sameTag.length >= limit) {
+    return sameTag.slice(0, limit)
+  }
+
+  const seen = new Set(sameTag.map((post) => post.id))
+  seen.add(current.id)
+  const rest = all.filter((post) => !seen.has(post.id))
+  return [...sameTag, ...rest].slice(0, limit)
+}

--- a/src/lib/sitemap-dates.ts
+++ b/src/lib/sitemap-dates.ts
@@ -1,0 +1,63 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { websiteUrl } from './content.ts'
+
+function stripSlash(url: string): string {
+  return url.replace(/\/+$/, '')
+}
+
+function frontmatterField(source: string, name: string): string | undefined {
+  const block = source.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  if (!block) {
+    return undefined
+  }
+  const match = block[1].match(new RegExp(`^${name}:\\s*['"]?([^\\n'"]+)`, 'm'))
+  return match?.[1]?.trim()
+}
+
+export function loadSitemapLastmods(): Map<string, string> {
+  const blogDir = join(dirname(fileURLToPath(import.meta.url)), '../content/blog')
+  const lastmods = new Map<string, string>()
+  const latestByTag = new Map<string, Date>()
+  let latestPost: Date | undefined
+
+  for (const file of readdirSync(blogDir)) {
+    if (!file.endsWith('.mdx') && !file.endsWith('.md')) {
+      continue
+    }
+    const source = readFileSync(join(blogDir, file), 'utf8')
+    if (frontmatterField(source, 'status') !== 'published') {
+      continue
+    }
+    const dateValue = frontmatterField(source, 'date')
+    if (!dateValue) {
+      continue
+    }
+    const date = new Date(`${dateValue}T00:00:00.000Z`)
+    if (Number.isNaN(date.getTime())) {
+      continue
+    }
+    const id = file.replace(/\.mdx?$/, '')
+    lastmods.set(stripSlash(`${websiteUrl}/${id}`), date.toISOString())
+    if (!latestPost || date > latestPost) {
+      latestPost = date
+    }
+    const tag = frontmatterField(source, 'tag')
+    if (tag) {
+      const current = latestByTag.get(tag)
+      if (!current || date > current) {
+        latestByTag.set(tag, date)
+      }
+    }
+  }
+
+  if (latestPost) {
+    lastmods.set(stripSlash(websiteUrl), latestPost.toISOString())
+  }
+  for (const [tag, date] of latestByTag) {
+    lastmods.set(stripSlash(`${websiteUrl}/tag/${tag}`), date.toISOString())
+  }
+
+  return lastmods
+}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,7 +3,7 @@ import { Stethoscope } from '@lucide/astro'
 import Container from '@/components/ui/Container.astro'
 import Layout from '@/layouts/Layout.astro'
 ---
-<Layout title="Page not found" robots="noindex, follow">
+<Layout title="Page not found" robots="noindex, follow" canonical={false}>
   <Container class="flex h-[calc(100vh-320px)] items-center justify-center mx-auto">
     <div class="flex flex-col items-center space-y-4">
       <Stethoscope size={24} aria-hidden="true" class="text-black dark:text-white" />

--- a/src/pages/[id]/index.astro
+++ b/src/pages/[id]/index.astro
@@ -8,6 +8,7 @@ import BlogStickyHeader from '@/components/BlogStickyHeader.astro'
 import Breadcrumbs from '@/components/Breadcrumbs.astro'
 import MarkdownLink from '@/components/MarkdownLink.astro'
 import { components } from '@/components/mdx'
+import TableOfContents from '@/components/TableOfContents.astro'
 import Container from '@/components/ui/Container.astro'
 import Figure from '@/components/ui/Figure.astro'
 import Heading from '@/components/ui/Heading.astro'
@@ -15,6 +16,7 @@ import Prose from '@/components/ui/Prose.astro'
 import Layout from '@/layouts/Layout.astro'
 import { authorFullName, websiteUrl } from '@/lib/content'
 import { countWords, readingTimeLabel } from '@/lib/reading-time'
+import { relatedPosts } from '@/lib/related-posts'
 import { absoluteUrl, blogBreadcrumbs, blogPostingJsonLd, isoDate } from '@/lib/schema'
 
 interface Props {
@@ -32,7 +34,7 @@ export async function getStaticPaths(): Promise<ReturnType<GetStaticPaths>> {
 }
 
 const { post } = Astro.props
-const { Content } = await render(post)
+const { Content, headings } = await render(post)
 const tag = await getEntry(post.data.tag.collection, post.data.tag.id)
 if (!tag) {
   throw new Error('Tag not found')
@@ -43,9 +45,8 @@ const minute_to_read = readingTimeLabel(post.body)
 const posts = await getCollection('blog', ({ data }) => data.status === 'published')
 posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
 const index = posts.findIndex((p) => p.id === post.id)
-const suggestions = [posts.at(index - 2), posts.at(index - 1)].filter(
-  Boolean,
-) as CollectionEntry<'blog'>[]
+const suggestions = relatedPosts(post, posts)
+const relatedAreSameTag = suggestions.every((item) => item.data.tag.id === post.data.tag.id)
 const publishedTime = isoDate(post.data.date)
 const markdownUrl = `${websiteUrl}/${post.id}.md`
 const url = absoluteUrl(`/${post.id}`)
@@ -61,7 +62,7 @@ const crumbs = blogBreadcrumbs(post, tag)
   jsonLd={blogPostingJsonLd(post, tag)}
   canonical={post.data.canonical_url}
   article={{
-    authors: [authorFullName],
+    authors: [authorFullName, absoluteUrl('/about')],
     publishedTime,
     modifiedTime: publishedTime,
     tags: [tag.data.title],
@@ -126,6 +127,7 @@ const crumbs = blogBreadcrumbs(post, tag)
         )
       }
     </header>
+    <TableOfContents {headings} />
     <BlogStickyHeader {post} />
     <Prose as="div" itemprop="articleBody">
       <Content {components} />
@@ -138,7 +140,19 @@ const crumbs = blogBreadcrumbs(post, tag)
       <section class="mt-24 bg-[#f6f6f6] dark:bg-[#2f333c] py-12 px-[4vw]">
         <Container size="tight" class="mx-auto">
           <h2 class="mb-4 text-xl font-extrabold dark:text-white">
-            You might also like...
+            {
+              relatedAreSameTag ? (
+                <>
+                  More{' '}
+                  <a href={`/tag/${tag.id}`} class="text-orange-400 hover:text-orange-300">
+                    {tag.data.title}
+                  </a>{' '}
+                  posts
+                </>
+              ) : (
+                'You might also like...'
+              )
+            }
           </h2>
           <div class="divide-y divide-slate-200 dark:divide-neutral-700">
             {suggestions.map((post) => (

--- a/src/pages/[id]/index.astro
+++ b/src/pages/[id]/index.astro
@@ -62,7 +62,7 @@ const crumbs = blogBreadcrumbs(post, tag)
   jsonLd={blogPostingJsonLd(post, tag)}
   canonical={post.data.canonical_url}
   article={{
-    authors: [authorFullName, absoluteUrl('/about')],
+    authors: [authorFullName],
     publishedTime,
     modifiedTime: publishedTime,
     tags: [tag.data.title],

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,17 +30,21 @@ const markdownUrl = `${websiteUrl}/index.md`
     <div class="-mt-8 mx-auto mb-4 flex max-w-lg flex-col items-center text-center">
       <div class="relative mb-8" itemscope itemtype="https://schema.org/ImageObject">
         <Image
-          alt="Engineering with Yagiz"
+          alt="Yagiz Nizipli"
           src={familyImg}
           width={150}
           height={150}
           loading="eager"
+          fetchpriority="high"
           class="rounded-full"
           itemprop="contentUrl"
         />
-        <meta itemprop="caption" content="Engineering with Yagiz" />
+        <meta itemprop="caption" content="Yagiz Nizipli" />
       </div>
-      <h1 class="sr-only" itemprop="name">{websiteTitle}</h1>
+      <h1 class="mb-3 text-2xl font-extrabold text-slate-800 dark:text-white">
+        Yagiz Nizipli
+      </h1>
+      <meta itemprop="name" content={websiteTitle} />
       <meta itemprop="description" content={websiteDescription} />
       <div class="text-lg dark:text-zinc-200">
         Here's a collection of posts about my thoughts, stories, ideas and

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -13,7 +13,12 @@ export async function GET(): Promise<ReturnType<APIRoute>> {
     title: websiteTitle,
     description: websiteDescription,
     site: new URL(websiteUrl),
+    xmlns: {
+      atom: 'http://www.w3.org/2005/Atom',
+    },
+    trailingSlash: false,
     customData: `
+<atom:link href="${websiteUrl}/rss.xml" rel="self" type="application/rss+xml"/>
 <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
 <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
 <language>en-us</language>
@@ -23,10 +28,10 @@ export async function GET(): Promise<ReturnType<APIRoute>> {
       return {
         title: post.data.title,
         description: post.data.description,
-        customData: `<guid>${`/${post.id}`}</guid>`,
         link: `/${post.id}`,
         pubDate: post.data.date,
         author: authorFullName,
+        categories: [post.data.tag.id],
       }
     }),
   })

--- a/src/pages/tag/[id].astro
+++ b/src/pages/tag/[id].astro
@@ -35,7 +35,7 @@ const crumbs = tagBreadcrumbs(tag)
 ---
 
 <Layout
-  title={tag.data.title}
+  title={`${tag.data.title} articles`}
   description={tag.data.description}
   markdownUrl={markdownUrl}
   jsonLd={tagCollectionJsonLd(tag, posts)}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,6 +2,7 @@ import { handle } from '@astrojs/cloudflare/handler'
 import {
   appendLink,
   appendVaryAccept,
+  isAgentOnlyPath,
   isImmutableAsset,
   markdownPath,
   preferredType,
@@ -29,6 +30,19 @@ function withHeaders(response: Response, mutate: (headers: Headers) => void): Re
 
 const PAGE_CDN_CACHE = 'public, max-age=3600, stale-while-revalidate=86400'
 const ASSET_CDN_CACHE = 'public, max-age=31536000, immutable'
+
+function applySeoHeaders(request: Request, response: Response): Response {
+  const pathname = new URL(request.url).pathname
+  return withHeaders(response, (headers) => {
+    if (isAgentOnlyPath(pathname)) {
+      headers.set('X-Robots-Tag', 'noindex, nofollow')
+      return
+    }
+    if (response.status === 404) {
+      headers.set('X-Robots-Tag', 'noindex, follow')
+    }
+  })
+}
 
 function applyCdnCache(request: Request, response: Response): Response {
   if (request.method !== 'GET' && request.method !== 'HEAD') {
@@ -66,7 +80,7 @@ export default {
     const url = new URL(request.url)
 
     if (shouldSkipNegotiation(url.pathname)) {
-      return applyCdnCache(request, await handle(request, env, ctx))
+      return applySeoHeaders(request, applyCdnCache(request, await handle(request, env, ctx)))
     }
 
     const accept = request.headers.get('accept')
@@ -85,6 +99,7 @@ export default {
           request,
           withHeaders(mdResponse, (headers) => {
             headers.set('Content-Type', 'text/markdown; charset=utf-8')
+            headers.set('X-Robots-Tag', 'noindex, nofollow')
             appendVaryAccept(headers)
             appendLink(
               headers,
@@ -102,14 +117,17 @@ export default {
     }
 
     const response = await handle(request, env, ctx)
-    return applyCdnCache(
+    return applySeoHeaders(
       request,
-      withHeaders(response, (headers) => {
-        appendVaryAccept(headers)
-        if (headers.get('content-type')?.includes('text/html')) {
-          appendLink(headers, `<${mdPath}>; rel="alternate"; type="text/markdown"`)
-        }
-      }),
+      applyCdnCache(
+        request,
+        withHeaders(response, (headers) => {
+          appendVaryAccept(headers)
+          if (headers.get('content-type')?.includes('text/html')) {
+            appendLink(headers, `<${mdPath}>; rel="alternate"; type="text/markdown"`)
+          }
+        }),
+      ),
     )
   },
 } satisfies ExportedHandler<Env>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -99,7 +99,9 @@ export default {
           request,
           withHeaders(mdResponse, (headers) => {
             headers.set('Content-Type', 'text/markdown; charset=utf-8')
-            headers.set('X-Robots-Tag', 'noindex, nofollow')
+            // Robots tags apply to the request URL, not the representation.
+            // The .md asset is noindex; do not copy that onto /about.
+            headers.delete('X-Robots-Tag')
             appendVaryAccept(headers)
             appendLink(
               headers,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
---
type: feature
intent: Improve crawl, titles, internal links, and snippet quality after the JSON-LD pass
app-source-changed: true
constraints: typescript@6, markdown-processor: unified
verify:
  - node --run lint
  - node --run build
preview: https://cursor-seo-ranking-signals-b6e5-yagiz.nizipli.workers.dev
---

## Summary

[#215](https://github.com/anonrig/yagiz.co/pull/215) covered JSON-LD and microdata. That helps rich results, not rankings. This follow-up targets signals Google actually uses:

- Sitemap `lastmod` from each post's frontmatter date (home and tag pages use the newest post in that set). Static pages stay without a fake build-clock date.
- Related posts prefer the same tag, and the heading links to the tag collection.
- Long posts get an "On this page" table of contents from MDX headings (3+ h2/h3).
- Document titles use `Title · Yagiz Nizipli`. Tag pages are `{Tag} articles · Yagiz Nizipli`.
- Home H1 is visible (`Yagiz Nizipli`) instead of screen-reader-only. LCP image uses `fetchpriority="high"`.
- Worker + `public/_headers` set `X-Robots-Tag: noindex` on `.md`, `llms.txt`, and 404. 404 no longer claims a canonical URL.
- RSS `guid`s are absolute URLs, with `atom:link` self and tag categories.
- Newsletter is in the header (sm+). About and several tag/post descriptions now match the actual page.

Review follow-ups:

- `article:author` is a single display name again. The about URL stays on `rel=author` so Open Graph does not invent a second writer.
- Markdown via `Accept: text/markdown` on an HTML path (`/about`) no longer sends `X-Robots-Tag: noindex`. Robots tags apply to the URL, so that header would have hidden the HTML page. Dedicated `.md` / `llms*.txt` / 404 responses stay noindex.

## Non-goals

- No extra schema.org types (SearchAction, FAQ, HowTo)
- No rewriting every blog post
- No keyword stuffing
- Rankings still depend on crawl, links, and content — this does not promise a position change

## Test plan

- [x] `node --run lint`
- [x] `node --run build`
- [x] Posts emit one `article:author` (`Yagiz Nizipli`) and `link rel=author` to `/about`
- [ ] Home `<h1>` is visible "Yagiz Nizipli"; title remains `Yagiz Nizipli's blog`
- [ ] Tag title is `Performance articles · Yagiz Nizipli`
- [ ] A long post (e.g. `/simd-is-the-wrong-way-to-parse-ipv4`) shows "On this page" and "More Performance posts"
- [x] `sitemap-0.xml` has lastmod on posts/home/tags, not on `/about` or `/contact`, and no `.md` / `llms*.txt`
- [x] `GET /contact.md` and `GET /llms.txt` send `X-Robots-Tag: noindex, nofollow`
- [x] `GET /missing` is 404 with `X-Robots-Tag: noindex` and no `rel=canonical`
- [x] `GET /about` with `Accept: text/markdown` is `text/markdown` + `Vary: Accept` and **no** `X-Robots-Tag: noindex`
- [ ] `GET /rss.xml` has absolute guids and atom:link
- [x] Markdown / Worker / sitemap:
  - [x] `GET /llms.txt` → `200 text/plain`
  - [x] `GET /llms-full.txt` → `200 text/plain`
  - [x] `GET /about.md` → YAML frontmatter + `X-Robots-Tag: noindex`
  - [x] `Accept: text/markdown` on `/about` → `text/markdown` + `Vary: Accept` (no noindex)
  - [x] HTML has `Link: rel="alternate"; type="text/markdown"`
  - [x] `Accept: application/pdf` → `406`
  - [x] sitemap lists HTML only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

