### PR TITLE
Drop leftover React JSX settings from TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    },
-    "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    }
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
---
type: chore
intent: Stop TypeScript targeting React JSX when the site is already Astro plus vanilla JS
app-source-changed: false
constraints: typescript@6
verify:
  - node --run lint
  - node --run build
preview:
---

## Summary

This site has no React runtime: no `react` / `@astrojs/react` dependency, no `.tsx` / `.jsx` files, and client interactivity already lives in Astro `<script>` plus vanilla JS. Satori OG trees are object literals, not React JSX.

The only leftover was `tsconfig.json` overriding Astro’s base with `"jsx": "react-jsx"` and `"jsxImportSource": "react"` (from the Next.js → Astro move). That override is removed so Astro’s `"jsx": "preserve"` applies.

`import React from 'react'` in `securing-your-nextjs-13-application.mdx` is a fenced code sample, not a real import.

## Non-goals

- Rewriting blog posts that mention React as a topic
- Changing Satori OG trees, MDX components, or client scripts (already non-React)
- Adding a React removal from `package.json` (there is nothing to remove)

## Test plan

- [x] `node --run lint`
- [x] `node --run build`
- [ ] Markdown / Worker / sitemap LLM surfaces — N/A (tsconfig only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

