### PR TITLE
Add URL-parsing series, updated dates, and snippet metas

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -92,6 +92,7 @@ export default defineConfig({
   routeRules: {
     '/': pageCache,
     '/about': pageCache,
+    '/url-parsing': pageCache,
     '/contact': pageCache,
     '/newsletter': pageCache,
     '/press': pageCache,

--- a/src/components/BlogFooter.astro
+++ b/src/components/BlogFooter.astro
@@ -20,15 +20,15 @@ const previous = index !== posts.length - 1 ? posts.at(index + 1) : undefined
 ---
 
 <Container size="tight" class="mt-16 flex items-center mx-auto px-[4vw]" as="footer">
-  <div class="flex flex-2 text-black dark:text-neutral-400">
+  <div class="flex min-w-0 flex-2 text-black dark:text-neutral-400">
     {
       previous !== undefined && (
         <a
           href={`/${previous.id}`}
-          aria-label={`Previous article: ${previous.data.title}`}
-          class="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 rounded"
+          class="flex min-w-0 items-center gap-2 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
         >
-          <ArrowLeft size={20} aria-hidden="true" />
+          <ArrowLeft size={20} aria-hidden="true" class="shrink-0" />
+          <span class="truncate text-sm font-medium">{previous.data.title}</span>
         </a>
       )
     }
@@ -64,15 +64,15 @@ const previous = index !== posts.length - 1 ? posts.at(index + 1) : undefined
     </div>
   </div>
 
-  <div class="flex flex-2 justify-end text-black dark:text-neutral-400">
+  <div class="flex min-w-0 flex-2 justify-end text-black dark:text-neutral-400">
     {
       next !== undefined && (
         <a
           href={`/${next.id}`}
-          aria-label={`Next article: ${next.data.title}`}
-          class="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 rounded"
+          class="flex min-w-0 items-center justify-end gap-2 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
         >
-          <ArrowRight size={20} aria-hidden="true" />
+          <span class="truncate text-sm font-medium">{next.data.title}</span>
+          <ArrowRight size={20} aria-hidden="true" class="shrink-0" />
         </a>
       )
     }

--- a/src/components/BlogRow.astro
+++ b/src/components/BlogRow.astro
@@ -7,9 +7,10 @@ import { absoluteUrl } from '@/lib/schema'
 interface Props {
   post: CollectionEntry<'blog'>
   itemprop?: string
+  heading?: 'h2' | 'h3'
 }
 
-const { post, itemprop } = Astro.props
+const { post, itemprop, heading: HeadingTag = 'h2' } = Astro.props
 const minute_to_read = readingTimeLabel(post.body)
 const formattedDate = new Intl.DateTimeFormat('en-US', {
   month: 'short',
@@ -38,12 +39,12 @@ const url = absoluteUrl(`/${post.id}`)
   <div
     class="overflow-hidden whitespace-nowrap text-ellipsis w-full pr-4 leading-6"
   >
-    <h2
+    <HeadingTag
       class="truncate font-normal dark:text-white dark:group-hover:text-neutral-300 group-hover:text-slate-600"
       itemprop="headline"
     >
       {post.data.title}
-    </h2>
+    </HeadingTag>
   </div>
   <div
     class="items-center transition-margin delay-0 duration-200 ease-in-out group-hover:mr-2 hidden sm:flex"

--- a/src/components/SeriesNav.astro
+++ b/src/components/SeriesNav.astro
@@ -1,0 +1,50 @@
+---
+import type { CollectionEntry } from 'astro:content'
+import { SERIES, type SeriesId } from '@/lib/series'
+
+interface Props {
+  seriesId: SeriesId
+  previous?: CollectionEntry<'blog'>
+  next?: CollectionEntry<'blog'>
+}
+
+const { seriesId, previous, next } = Astro.props
+const series = SERIES[seriesId]
+---
+
+<aside class="col-main mb-8 rounded-lg border border-slate-200 px-4 py-3 text-left dark:border-neutral-700">
+  <p class="text-sm text-slate-600 dark:text-neutral-300">
+    Part of{' '}
+    <a href={series.path} class="font-bold text-orange-400 hover:text-orange-300">
+      {series.title}
+    </a>
+  </p>
+  {
+    (previous || next) && (
+      <nav aria-label={`${series.title} series`} class="mt-2 flex justify-between gap-4 text-sm">
+        {previous ? (
+          <a
+            href={`/${previous.id}`}
+            class="min-w-0 text-slate-700 hover:text-slate-500 dark:text-zinc-200 dark:hover:text-zinc-400"
+          >
+            <span aria-hidden="true">← </span>
+            <span class="font-medium">{previous.data.title}</span>
+          </a>
+        ) : (
+          <span />
+        )}
+        {next ? (
+          <a
+            href={`/${next.id}`}
+            class="min-w-0 text-right text-slate-700 hover:text-slate-500 dark:text-zinc-200 dark:hover:text-zinc-400"
+          >
+            <span class="font-medium">{next.data.title}</span>
+            <span aria-hidden="true"> →</span>
+          </a>
+        ) : (
+          <span />
+        )}
+      </nav>
+    )
+  }
+</aside>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -8,6 +8,7 @@ export interface Item {
 
 const footerItems: Item[] = [
   { title: 'About', href: '/about' },
+  { title: 'URL parsing', href: '/url-parsing' },
   { title: 'Press', href: '/press' },
   { title: 'Newsletter', href: '/newsletter' },
   { title: 'Contact', href: '/contact' },

--- a/src/components/mdx/Image.astro
+++ b/src/components/mdx/Image.astro
@@ -18,26 +18,24 @@ const loadImage = images[key]
 if (isAsset && loadImage === undefined) {
   throw new Error('src should not be empty')
 }
+
+const asset = isAsset && loadImage ? (await loadImage()).default : undefined
+const imageClass = [
+  'rounded-lg object-contain w-full !h-[unset] !relative bg-white dark:bg-white-reversed col-wide',
+  className,
+]
 ---
 
 {
-  !isAsset ? (
-    <img
-      {src}
+  asset ? (
+    <AstroImage
+      src={asset}
       {alt}
-      class:list={[
-        "rounded-lg object-contain w-full !h-[unset] !relative bg-white dark:bg-white-reversed col-wide",
-        className,
-      ]}
+      width={asset.width}
+      height={asset.height}
+      class:list={imageClass}
     />
   ) : (
-    <AstroImage
-      src={loadImage()}
-      {alt}
-      class:list={[
-        "rounded-lg object-contain w-full !h-[unset] !relative bg-white dark:bg-white-reversed col-wide",
-        className,
-      ]}
-    />
+    <img {src} {alt} loading="lazy" decoding="async" class:list={imageClass} />
   )
 }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -5,26 +5,27 @@ import { z } from 'astro/zod'
 const blog = defineCollection({
   loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: './src/content/blog' }),
   schema: ({ image }) =>
-    z.object({
-      title: z.string(),
-      description: z.string(),
-      date: z.coerce.date(),
-      tag: reference('tags'),
-      image: z
-        .object({
-          src: z.preprocess((v) => `@/assets/content/${v}`, image()),
-          alt: z.string().min(1),
-        })
-        .optional(),
-      status: z.enum(['published', 'draft']),
-      canonical_url: z.string().optional(),
-      updated: z.coerce.date().optional(),
-      series: z.enum(['url-parsing']).optional(),
-    })
-    .refine((data) => !data.updated || data.updated.getTime() >= data.date.getTime(), {
-      message: 'updated must be on or after date',
-      path: ['updated'],
-    }),
+    z
+      .object({
+        title: z.string(),
+        description: z.string(),
+        date: z.coerce.date(),
+        tag: reference('tags'),
+        image: z
+          .object({
+            src: z.preprocess((v) => `@/assets/content/${v}`, image()),
+            alt: z.string().min(1),
+          })
+          .optional(),
+        status: z.enum(['published', 'draft']),
+        canonical_url: z.string().optional(),
+        updated: z.coerce.date().optional(),
+        series: z.enum(['url-parsing']).optional(),
+      })
+      .refine((data) => !data.updated || data.updated.getTime() >= data.date.getTime(), {
+        message: 'updated must be on or after date',
+        path: ['updated'],
+      }),
 })
 
 const tags = defineCollection({

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -13,11 +13,17 @@ const blog = defineCollection({
       image: z
         .object({
           src: z.preprocess((v) => `@/assets/content/${v}`, image()),
-          alt: z.string().optional().default(''),
+          alt: z.string().min(1),
         })
         .optional(),
       status: z.enum(['published', 'draft']),
       canonical_url: z.string().optional(),
+      updated: z.coerce.date().optional(),
+      series: z.enum(['url-parsing']).optional(),
+    })
+    .refine((data) => !data.updated || data.updated.getTime() >= data.date.getTime(), {
+      message: 'updated must be on or after date',
+      path: ['updated'],
     }),
 })
 

--- a/src/content/blog/announcing-ada-url-parser-v2-0.mdx
+++ b/src/content/blog/announcing-ada-url-parser-v2-0.mdx
@@ -1,9 +1,11 @@
 ---
 title: 'Announcing Ada URL parser v2.0'
 description: >-
-  Ada URL Parser, a powerful tool for parsing URLs, has just been updated to version 2.0 after the release of version 1.0.4 just a month ago.
+  Ada 2.0 drops the ICU dependency, adds url_aggregator for one-shot parses,
+  and roughly doubles throughput on some workloads.
 date: 2023-03-30
 tag: performance
+series: url-parsing
 status: published
 image:
   src: ada-url-parser.png

--- a/src/content/blog/cordova-react-native-swift.mdx
+++ b/src/content/blog/cordova-react-native-swift.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Cordova, React Native, Swift: What is really next?'
 description: >-
-  I'm quite excited about writing about mobile application development. It has been in my mind for quite some time now.
+  A 2020 comparison of Cordova, React Native, and native Swift for mobile apps.
 date: 2020-11-22
 tag: coding
 status: published

--- a/src/content/blog/dear-20-year-old-software-engineer.mdx
+++ b/src/content/blog/dear-20-year-old-software-engineer.mdx
@@ -1,7 +1,8 @@
 ---
 title: 'Dear 20 year old Software Engineer'
 description: >-
-  Before writing a letter to 20 year old me, it’s better to introduce myself. I am a Computer Engineering student at Sabanci University, Istanbul, Turkey. I’ve worked for more than 5 companies which ranges from startups to corporations.
+  A 2015 letter to a 20-year-old engineer: career choices, burnout, and what
+  actually compounds.
 type: Blog
 date: '2024-05-02'
 tag: personal

--- a/src/content/blog/developing-fast-builtin-task-runner.mdx
+++ b/src/content/blog/developing-fast-builtin-task-runner.mdx
@@ -1,7 +1,8 @@
 ---
 title: 'Developing fast & built-in task runner in Node.js core'
 description: >-
-  With this blog post, I'm going to explain and analyze the steps I've taken to land a super-fast, built-in task runner in Node.js core. For those who are not familiar with the term "task runner", it's a command-line tool to run a task specified in a `package.json` file in node.js projects.
+  How Node.js got a built-in task runner, and the steps that made `node --run`
+  fast.
 type: Blog
 date: '2024-06-17'
 tag: coding

--- a/src/content/blog/implementing-node-js-url-parser-in-webassembly-with-rust.mdx
+++ b/src/content/blog/implementing-node-js-url-parser-in-webassembly-with-rust.mdx
@@ -1,9 +1,11 @@
 ---
 title: Implementing Node.js URL parser in WebAssembly with Rust
 description: >-
-  Even though, this started as an experiment, implementing the URL parser in Rust using WebAssembly became the graduation project for my Masters in Computer Science at Fordham University.
+  A Fordham capstone: reimplementing Node's WHATWG URL parser in Rust and
+  WebAssembly to cut C++ bridge cost.
 date: 2022-02-28
 tag: performance
+series: url-parsing
 status: published
 image:
   src: url-structure-composition.png

--- a/src/content/blog/improving-nodejs-loader-performance.mdx
+++ b/src/content/blog/improving-nodejs-loader-performance.mdx
@@ -1,7 +1,8 @@
 ---
 title: Improving Node.js loader performance
 description: >-
-  CommonJS and ES modules are 2 sides of a coin. Node.js supports both of them. So, how can we improve the performance of Node.js loaders?
+  Where CommonJS and ESM loaders spend time in Node.js, and what we changed to
+  make them faster.
 date: 2023-12-12
 tag: performance
 status: published

--- a/src/content/blog/performance-metrics-and-benchmarking-nodejs.mdx
+++ b/src/content/blog/performance-metrics-and-benchmarking-nodejs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Performance metrics and benchmarking on Node.js
 description: >-
-  Lately, I've found myself worrying more and more about performance and the amount of time it takes for a function or a task to be taken on Node.js.
+  How to time Node.js functions with perf_hooks without fooling yourself.
 date: 2021-05-16
 tag: performance
 status: published

--- a/src/content/blog/performance-tips-for-c-developers.mdx
+++ b/src/content/blog/performance-tips-for-c-developers.mdx
@@ -1,7 +1,8 @@
 ---
 title: 'Performance tips for C++ developers'
 description: >-
-  C++ is a powerful and versatile programming language that is widely used for a variety of applications, including system programming, game development, and scientific computing.
+  Practical C++ performance notes: avoid copies, pick the right container, and
+  let the compiler see the hot path.
 date: 2023-03-24
 tag: performance
 status: published

--- a/src/content/blog/postgresql-index-performance.mdx
+++ b/src/content/blog/postgresql-index-performance.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'PostgreSQL: Optimizations and indexes'
 description: >-
-  Today, I'm going to talk about one of the most interesting topics in software and computer engineering, performance. PostgreSQL, as one of the most advanced database management systems out there.
+  PostgreSQL 14 index types, when they help, and how to read the query planner.
 date: 2022-02-26
 tag: database
 status: published

--- a/src/content/blog/recap-2023.mdx
+++ b/src/content/blog/recap-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Recap 2023 - The year of hard work and new beginnings'
 description: >-
-  It's been a really long year. I've had a lot of ups and downs, but I'm glad I've made it through. I'm looking forward to the next year, and I hope it's a good one.
+  A 2023 recap: Ada, Node.js TSC work, talks, and becoming a parent.
 date: '2023-12-25'
 tag: personal
 status: published

--- a/src/content/blog/reducing-the-cost-of-string-serialization-in-nodejs-core.mdx
+++ b/src/content/blog/reducing-the-cost-of-string-serialization-in-nodejs-core.mdx
@@ -1,9 +1,11 @@
 ---
 title: 'Reducing the cost of string serialization in Node.js core'
 description: >-
-  Serializing strings in Node.js has been a pain point for web developers, particularly when it comes to URL operations. Recently, we conducted a research to reduce the cost of string serialization in Node.js core particularly in the context of URL parsing, resulting in a series of optimizations that addressed the issue.
+  How we cut string serialization cost in Node.js URL operations, work that
+  landed in Ada 2.0.
 date: 2023-04-25
 tag: performance
+series: url-parsing
 status: published
 ---
 

--- a/src/content/blog/release-of-ada-v3.mdx
+++ b/src/content/blog/release-of-ada-v3.mdx
@@ -1,11 +1,12 @@
 ---
 title: 'Release of Ada v3.0 with URLPattern'
 description: >-
-  Announcing Ada's new release with URLPattern, a new feature that allows you to
-  define URL patterns for your routes.
+  Ada 3.0 adds URLPattern matching for routes, used in Node.js, ClickHouse, and
+  Cloudflare Workers.
 type: Blog
 date: '2025-01-30'
 tag: performance
+series: url-parsing
 status: published
 ---
 

--- a/src/content/blog/release-of-ada-v4.mdx
+++ b/src/content/blog/release-of-ada-v4.mdx
@@ -5,6 +5,7 @@ description: >-
   URL parsing with max-length limits, ABI soname 4, and a wave of correctness fixes.
 date: '2026-07-27'
 tag: performance
+series: url-parsing
 status: published
 image:
   src: ada-url-parser.png

--- a/src/content/blog/securing-your-nextjs-13-application.mdx
+++ b/src/content/blog/securing-your-nextjs-13-application.mdx
@@ -1,9 +1,7 @@
 ---
 title: Securing your Next.js 13 application
 description: >-
-  Next.js is a popular framework for building server-side rendered React
-  applications, but like any web application, it's crucial to take security
-  seriously.
+  Security headers, CSP, and CSRF protections that matter in a Next.js 13 app.
 date: 2023-04-22
 tag: security
 status: published

--- a/src/content/blog/simd-is-the-wrong-way-to-parse-ipv4.mdx
+++ b/src/content/blog/simd-is-the-wrong-way-to-parse-ipv4.mdx
@@ -6,6 +6,7 @@ description: >-
   front of it, and only then reach for AVX-512.
 date: '2026-08-24'
 tag: performance
+series: url-parsing
 status: published
 ---
 

--- a/src/content/blog/state-of-url-parsing-2025.mdx
+++ b/src/content/blog/state-of-url-parsing-2025.mdx
@@ -5,6 +5,7 @@ description: >-
 type: Blog
 date: '2025-12-09'
 tag: performance
+series: url-parsing
 status: published
 ---
 

--- a/src/content/blog/sudoku-generating-valid-one.mdx
+++ b/src/content/blog/sudoku-generating-valid-one.mdx
@@ -1,7 +1,8 @@
 ---
 title: 'How to generate a valid and fast Sudoku board from scratch?'
 description: >-
-  I don't believe I'm writing a blog post related to Sudoku since it's already a solved problem/exercise and it's widely known, but I wanted to share my experience and my thought thinking about creating a valid Sudoku board and what it means to have a valid Sudoku.
+  How to generate a valid Sudoku board from scratch, and what “valid” actually
+  requires.
 date: 2021-10-15
 tag: algorithms
 status: published

--- a/src/content/blog/timing-attacks-on-node-js.mdx
+++ b/src/content/blog/timing-attacks-on-node-js.mdx
@@ -1,7 +1,8 @@
 ---
 title: 'Timing Attacks on Node.js'
 description: >-
-  I've been working with Node.js for quite a long time. So, believe me when I say there's a library called eslint-plugin-security to detect common mistakes and security flaws you make while you're coding.
+  How timing attacks show up in Node.js string comparison, and what
+  eslint-plugin-security actually flags.
 date: 2021-03-24
 tag: security
 status: published

--- a/src/content/blog/tracing-query-performance-with-knex-js.mdx
+++ b/src/content/blog/tracing-query-performance-with-knex-js.mdx
@@ -1,12 +1,14 @@
 ---
 title: 'Tracing query performance with Knex.js'
 description: >-
-  Over the years, I found myself searching for the same exact problem whenever I was using Knex.js, the query planner for Node.js.
+  A small Knex.js helper that uses perf_hooks to time queries and print planner
+  output so you can see why a query is slow.
 date: 2022-01-23
 tag: performance
 status: published
 image:
   src: knexjs-cover.png
+  alt: Knex.js query tracing
 ---
 
 Over the years, I found myself searching for the same exact problem whenever I was using Knex.js, the query planner for Node.js. Since, the following code snippet is small enough to not be a Node library, I'm intrigued to share this as a blog post.

--- a/src/content/blog/url-parsing-and-browser-differences.mdx
+++ b/src/content/blog/url-parsing-and-browser-differences.mdx
@@ -1,9 +1,11 @@
 ---
 title: 'URL specification and browser implementation differences'
 description: >-
-  Recently, I encountered a difference in output in Ada compared to Safari, Chrome and Firefox. I thought it would be a good idea to write a blog post and explain the difference, and how browser implementations of URL is not kept in sync with the URL specification.
+  Ada, Safari, Chrome, and Firefox disagree on some URLs. Why WHATWG and
+  browser engines drift, and what that means for parsers.
 date: 2023-05-25
 tag: algorithms
+series: url-parsing
 status: published
 ---
 

--- a/src/content/blog/whatwg-url-specification-for-toddlers.mdx
+++ b/src/content/blog/whatwg-url-specification-for-toddlers.mdx
@@ -1,9 +1,11 @@
 ---
 title: 'The story of WHATWG URL Specification for toddlers'
 description: >-
-  I recently wrote a tweet mentioning how I tell my newborn baby, Ada, the edge cases of URL specification for her to sleep.
+  A bedtime walk through WHATWG URL edge cases — told as a story for a newborn
+  named Ada.
 date: 2023-06-22
 tag: experimental
+series: url-parsing
 status: published
 image:
   src: toddler-url-story.png

--- a/src/content/blog/working-with-1000-tests.mdx
+++ b/src/content/blog/working-with-1000-tests.mdx
@@ -1,9 +1,11 @@
 ---
 title: 'Working with 1000+ tests on a stable C++ library'
 description: >-
-  Working on a project that handles every edge case of a URL specification and has over 1000 unit tests can be quite challenging. Recently, I had the opportunity to work on a refactor and a new API for the Ada URL Parser.
+  How we refactored Ada's C++ URL parser under a 1000+ test suite without
+  breaking WHATWG edge cases.
 date: 2023-03-18
 tag: coding
+series: url-parsing
 status: published
 ---
 

--- a/src/content/tags/database.mdx
+++ b/src/content/tags/database.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database
 description: >-
-  Notes on PostgreSQL, indexes, and making database queries faster.
+  A practical look at PostgreSQL indexes and query planning — when an index
+  helps, and when it does not.
 ---

--- a/src/content/tags/experimental.mdx
+++ b/src/content/tags/experimental.mdx
@@ -1,5 +1,6 @@
 ---
 title: Experimental
 description: >-
-  Side experiments and in-progress ideas from Yagiz Nizipli.
+  One-off experiments and in-progress notes, including a toddler-friendly walk
+  through WHATWG URL edge cases.
 ---

--- a/src/content/tags/personal.mdx
+++ b/src/content/tags/personal.mdx
@@ -1,5 +1,6 @@
 ---
 title: Personal
 description: >-
-  Articles involving my life, my hobbies and my interests. I'll try to keep this as minimal as possible, but I'll probably fail.
+  Recaps and letters about work, family, and the parts of engineering that are
+  not just code.
 ---

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -35,7 +35,7 @@ interface Props {
 const {
   title,
   description = websiteDescription,
-  image = `${Astro.url.origin}/opengraph-image.png`,
+  image = absoluteUrl('/opengraph-image.png'),
   imageAlt,
   markdownUrl,
   jsonLd,
@@ -114,8 +114,8 @@ const googlebot = noindex
     <meta name="twitter:site:id" content={twitterId} />
     <meta name="twitter:creator:id" content={twitterId} />
     <meta name="twitter:image:type" content="image/png" />
-    <meta name="twitter:image:width" content="1920" />
-    <meta name="twitter:image:height" content="1080" />
+    <meta name="twitter:image:width" content={String(openGraphImage.width)} />
+    <meta name="twitter:image:height" content={String(openGraphImage.height)} />
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="48x48" />
     <link
       rel="apple-touch-icon"

--- a/src/lib/related-posts.ts
+++ b/src/lib/related-posts.ts
@@ -5,15 +5,26 @@ export function relatedPosts(
   all: CollectionEntry<'blog'>[],
   limit = 3,
 ): CollectionEntry<'blog'>[] {
-  const sameTag = all.filter(
-    (post) => post.id !== current.id && post.data.tag.id === current.data.tag.id,
-  )
-  if (sameTag.length >= limit) {
-    return sameTag.slice(0, limit)
+  const others = all.filter((post) => post.id !== current.id)
+  const sameSeries = current.data.series
+    ? others.filter((post) => post.data.series === current.data.series)
+    : []
+  if (sameSeries.length >= limit) {
+    return sameSeries.slice(0, limit)
   }
 
-  const seen = new Set(sameTag.map((post) => post.id))
+  const seen = new Set(sameSeries.map((post) => post.id))
   seen.add(current.id)
-  const rest = all.filter((post) => !seen.has(post.id))
-  return [...sameTag, ...rest].slice(0, limit)
+  const sameTag = others.filter(
+    (post) => !seen.has(post.id) && post.data.tag.id === current.data.tag.id,
+  )
+  if (sameSeries.length + sameTag.length >= limit) {
+    return [...sameSeries, ...sameTag].slice(0, limit)
+  }
+
+  for (const post of sameTag) {
+    seen.add(post.id)
+  }
+  const rest = others.filter((post) => !seen.has(post.id))
+  return [...sameSeries, ...sameTag, ...rest].slice(0, limit)
 }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -10,6 +10,7 @@ import {
   websiteUrl,
 } from '@/lib/content'
 import { countWords, readingTimeIso } from '@/lib/reading-time'
+import { SERIES } from '@/lib/series'
 
 export type JsonLd = Record<string, unknown>
 
@@ -64,6 +65,10 @@ export function imageObject(
 
 export function isoDate(date: Date): string {
   return date.toISOString().split('T')[0]
+}
+
+export function postModifiedDate(post: CollectionEntry<'blog'>): Date {
+  return post.data.updated ?? post.data.date
 }
 
 export function personJsonLd(): JsonLd {
@@ -185,6 +190,10 @@ export function tagBreadcrumbs(tag: CollectionEntry<'tags'>): BreadcrumbItem[] {
   ]
 }
 
+export function seriesBreadcrumbs(name: string, path: string): BreadcrumbItem[] {
+  return pageBreadcrumbs(name, path)
+}
+
 function blogPostPreview(post: CollectionEntry<'blog'>): JsonLd {
   const url = absoluteUrl(`/${post.id}`)
   return {
@@ -193,6 +202,7 @@ function blogPostPreview(post: CollectionEntry<'blog'>): JsonLd {
     headline: post.data.title,
     url,
     datePublished: isoDate(post.data.date),
+    dateModified: isoDate(postModifiedDate(post)),
     description: post.data.description,
     author: { '@id': schemaIds.person },
     image: absoluteUrl(`/${post.id}/opengraph-image.png`),
@@ -244,7 +254,8 @@ export function blogPostingJsonLd(
   tag: CollectionEntry<'tags'>,
 ): JsonLd {
   const url = absoluteUrl(`/${post.id}`)
-  const date = isoDate(post.data.date)
+  const published = isoDate(post.data.date)
+  const modified = isoDate(postModifiedDate(post))
   const words = countWords(post.body)
   const crumbs = blogBreadcrumbs(post, tag)
   const image = imageObject(absoluteUrl(`/${post.id}/opengraph-image.png`), post.data.title)
@@ -273,8 +284,8 @@ export function blogPostingJsonLd(
         url,
         image,
         thumbnailUrl: absoluteUrl(`/${post.id}/opengraph-image.png`),
-        datePublished: date,
-        dateModified: date,
+        datePublished: published,
+        dateModified: modified,
         inLanguage: 'en-US',
         author: { '@id': schemaIds.person },
         publisher: { '@id': schemaIds.person },
@@ -285,7 +296,9 @@ export function blogPostingJsonLd(
         wordCount: words,
         timeRequired: readingTimeIso(post.body),
         isAccessibleForFree: true,
-        isPartOf: { '@id': schemaIds.blog },
+        isPartOf: post.data.series
+          ? [{ '@id': schemaIds.blog }, { '@id': absoluteUrl(SERIES[post.data.series].path) }]
+          : { '@id': schemaIds.blog },
         about: {
           '@type': 'Thing',
           name: tag.data.title,
@@ -464,6 +477,54 @@ export function newsletterPageJsonLd(title: string, description: string): JsonLd
       },
     },
   })
+}
+
+export function seriesCollectionJsonLd(
+  path: string,
+  title: string,
+  description: string,
+  posts: CollectionEntry<'blog'>[],
+): JsonLd {
+  const url = absoluteUrl(path)
+  const crumbs = seriesBreadcrumbs(title, path)
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      personJsonLd(),
+      websiteJsonLd(),
+      breadcrumbsJsonLd(url, crumbs),
+      {
+        '@type': 'CollectionPage',
+        '@id': url,
+        url,
+        name: title,
+        description,
+        inLanguage: 'en-US',
+        isPartOf: { '@id': schemaIds.blog },
+        breadcrumb: { '@id': `${url}#breadcrumb` },
+        about: {
+          '@type': 'Thing',
+          name: title,
+          url,
+        },
+        author: { '@id': schemaIds.person },
+        publisher: { '@id': schemaIds.person },
+        mainEntity: {
+          '@type': 'ItemList',
+          numberOfItems: posts.length,
+          itemListOrder: 'https://schema.org/ItemListOrderAscending',
+          itemListElement: posts.map((post, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            url: absoluteUrl(`/${post.id}`),
+            name: post.data.title,
+            item: blogPostPreview(post),
+          })),
+        },
+      },
+    ],
+  }
 }
 
 export function pressPageJsonLd(title: string, description: string): JsonLd {

--- a/src/lib/series.ts
+++ b/src/lib/series.ts
@@ -1,0 +1,56 @@
+import type { CollectionEntry } from 'astro:content'
+
+export const SERIES = {
+  'url-parsing': {
+    id: 'url-parsing',
+    title: 'URL parsing',
+    path: '/url-parsing',
+    description:
+      'A series on WHATWG URL parsing, Ada, Node.js, and the SIMD and serialization work behind them.',
+  },
+} as const
+
+export type SeriesId = keyof typeof SERIES
+
+export function isSeriesId(value: string): value is SeriesId {
+  return value in SERIES
+}
+
+export function seriesDefinition(id: SeriesId) {
+  return SERIES[id]
+}
+
+export function postsInSeries(
+  posts: CollectionEntry<'blog'>[],
+  id: SeriesId,
+): CollectionEntry<'blog'>[] {
+  return posts
+    .filter((post) => post.data.series === id)
+    .sort((a, b) => a.data.date.getTime() - b.data.date.getTime())
+}
+
+export function seriesNeighbors(
+  current: CollectionEntry<'blog'>,
+  all: CollectionEntry<'blog'>[],
+): {
+  series: (typeof SERIES)[SeriesId]
+  previous?: CollectionEntry<'blog'>
+  next?: CollectionEntry<'blog'>
+} | null {
+  if (!current.data.series) {
+    return null
+  }
+
+  const series = SERIES[current.data.series]
+  const ordered = postsInSeries(all, current.data.series)
+  const index = ordered.findIndex((post) => post.id === current.id)
+  if (index === -1) {
+    return null
+  }
+
+  return {
+    series,
+    previous: index > 0 ? ordered[index - 1] : undefined,
+    next: index < ordered.length - 1 ? ordered[index + 1] : undefined,
+  }
+}

--- a/src/lib/sitemap-dates.ts
+++ b/src/lib/sitemap-dates.ts
@@ -38,16 +38,27 @@ export function loadSitemapLastmods(): Map<string, string> {
     if (Number.isNaN(date.getTime())) {
       continue
     }
+    const updatedValue = frontmatterField(source, 'updated')
+    const updated = updatedValue ? new Date(`${updatedValue}T00:00:00.000Z`) : undefined
+    const modified =
+      updated && !Number.isNaN(updated.getTime()) && updated > date ? updated : date
     const id = file.replace(/\.mdx?$/, '')
-    lastmods.set(stripSlash(`${websiteUrl}/${id}`), date.toISOString())
-    if (!latestPost || date > latestPost) {
-      latestPost = date
+    lastmods.set(stripSlash(`${websiteUrl}/${id}`), modified.toISOString())
+    if (!latestPost || modified > latestPost) {
+      latestPost = modified
+    }
+    const series = frontmatterField(source, 'series')
+    if (series) {
+      const current = latestByTag.get(`series:${series}`)
+      if (!current || modified > current) {
+        latestByTag.set(`series:${series}`, modified)
+      }
     }
     const tag = frontmatterField(source, 'tag')
     if (tag) {
       const current = latestByTag.get(tag)
-      if (!current || date > current) {
-        latestByTag.set(tag, date)
+      if (!current || modified > current) {
+        latestByTag.set(tag, modified)
       }
     }
   }
@@ -55,8 +66,12 @@ export function loadSitemapLastmods(): Map<string, string> {
   if (latestPost) {
     lastmods.set(stripSlash(websiteUrl), latestPost.toISOString())
   }
-  for (const [tag, date] of latestByTag) {
-    lastmods.set(stripSlash(`${websiteUrl}/tag/${tag}`), date.toISOString())
+  for (const [key, date] of latestByTag) {
+    if (key.startsWith('series:')) {
+      lastmods.set(stripSlash(`${websiteUrl}/${key.slice('series:'.length)}`), date.toISOString())
+      continue
+    }
+    lastmods.set(stripSlash(`${websiteUrl}/tag/${key}`), date.toISOString())
   }
 
   return lastmods

--- a/src/lib/sitemap-dates.ts
+++ b/src/lib/sitemap-dates.ts
@@ -40,8 +40,7 @@ export function loadSitemapLastmods(): Map<string, string> {
     }
     const updatedValue = frontmatterField(source, 'updated')
     const updated = updatedValue ? new Date(`${updatedValue}T00:00:00.000Z`) : undefined
-    const modified =
-      updated && !Number.isNaN(updated.getTime()) && updated > date ? updated : date
+    const modified = updated && !Number.isNaN(updated.getTime()) && updated > date ? updated : date
     const id = file.replace(/\.mdx?$/, '')
     lastmods.set(stripSlash(`${websiteUrl}/${id}`), modified.toISOString())
     if (!latestPost || modified > latestPost) {

--- a/src/lib/to-markdown.ts
+++ b/src/lib/to-markdown.ts
@@ -40,15 +40,21 @@ export function absolutizeMarkdownUrls(body: string): string {
 
 export function postToMarkdown(post: CollectionEntry<'blog'>): string {
   const date = post.data.date.toISOString().split('T')[0]
+  const updated = post.data.updated?.toISOString().split('T')[0]
   const canonical = `${websiteUrl}/${post.id}`
   const markdownUrl = `${canonical}.md`
+  const publishedLine = updated
+    ? `*Published: ${date} · Updated: ${updated} · Tag: ${post.data.tag.id}*`
+    : `*Published: ${date} · Tag: ${post.data.tag.id}*`
 
   return [
     yamlFrontmatter({
       title: post.data.title,
       description: post.data.description,
       date,
+      updated,
       tag: post.data.tag.id,
+      series: post.data.series,
       author: authorFullName,
       canonical,
       markdown: markdownUrl,
@@ -58,7 +64,7 @@ export function postToMarkdown(post: CollectionEntry<'blog'>): string {
     '',
     `> ${post.data.description}`,
     '',
-    `*Published: ${date} · Tag: ${post.data.tag.id}*`,
+    publishedLine,
     '',
     '---',
     '',
@@ -117,6 +123,42 @@ export function tagToMarkdown(
     `# #${tag.data.title}`,
     '',
     `> ${tag.data.description}`,
+    '',
+    '---',
+    '',
+    postList,
+    ATTRIBUTION.replace(`Canonical: ${websiteUrl}`, `Canonical: ${canonical}`),
+  ].join('\n')
+}
+
+export function seriesToMarkdown(
+  title: string,
+  description: string,
+  path: string,
+  posts: CollectionEntry<'blog'>[],
+): string {
+  const canonical = `${websiteUrl}${path}`
+  const markdownUrl = `${canonical}.md`
+
+  const postList = posts
+    .map((post) => {
+      const date = post.data.date.toISOString().split('T')[0]
+      return `- [${post.data.title}](${websiteUrl}/${post.id}.md) — ${date}`
+    })
+    .join('\n')
+
+  return [
+    yamlFrontmatter({
+      title,
+      description,
+      author: authorFullName,
+      canonical,
+      markdown: markdownUrl,
+    }),
+    '',
+    `# ${title}`,
+    '',
+    `> ${description}`,
     '',
     '---',
     '',

--- a/src/pages/[id]/index.astro
+++ b/src/pages/[id]/index.astro
@@ -18,7 +18,13 @@ import Layout from '@/layouts/Layout.astro'
 import { authorFullName, websiteUrl } from '@/lib/content'
 import { countWords, readingTimeLabel } from '@/lib/reading-time'
 import { relatedPosts } from '@/lib/related-posts'
-import { absoluteUrl, blogBreadcrumbs, blogPostingJsonLd, isoDate, postModifiedDate } from '@/lib/schema'
+import {
+  absoluteUrl,
+  blogBreadcrumbs,
+  blogPostingJsonLd,
+  isoDate,
+  postModifiedDate,
+} from '@/lib/schema'
 import { seriesNeighbors } from '@/lib/series'
 
 interface Props {

--- a/src/pages/[id]/index.astro
+++ b/src/pages/[id]/index.astro
@@ -8,6 +8,7 @@ import BlogStickyHeader from '@/components/BlogStickyHeader.astro'
 import Breadcrumbs from '@/components/Breadcrumbs.astro'
 import MarkdownLink from '@/components/MarkdownLink.astro'
 import { components } from '@/components/mdx'
+import SeriesNav from '@/components/SeriesNav.astro'
 import TableOfContents from '@/components/TableOfContents.astro'
 import Container from '@/components/ui/Container.astro'
 import Figure from '@/components/ui/Figure.astro'
@@ -17,7 +18,8 @@ import Layout from '@/layouts/Layout.astro'
 import { authorFullName, websiteUrl } from '@/lib/content'
 import { countWords, readingTimeLabel } from '@/lib/reading-time'
 import { relatedPosts } from '@/lib/related-posts'
-import { absoluteUrl, blogBreadcrumbs, blogPostingJsonLd, isoDate } from '@/lib/schema'
+import { absoluteUrl, blogBreadcrumbs, blogPostingJsonLd, isoDate, postModifiedDate } from '@/lib/schema'
+import { seriesNeighbors } from '@/lib/series'
 
 interface Props {
   post: CollectionEntry<'blog'>
@@ -46,17 +48,24 @@ const posts = await getCollection('blog', ({ data }) => data.status === 'publish
 posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
 const index = posts.findIndex((p) => p.id === post.id)
 const suggestions = relatedPosts(post, posts)
+const relatedAreSameSeries = Boolean(
+  post.data.series && suggestions.every((item) => item.data.series === post.data.series),
+)
 const relatedAreSameTag = suggestions.every((item) => item.data.tag.id === post.data.tag.id)
 const publishedTime = isoDate(post.data.date)
+const modifiedDate = postModifiedDate(post)
+const modifiedTime = isoDate(modifiedDate)
+const showUpdated = modifiedTime !== publishedTime
 const markdownUrl = `${websiteUrl}/${post.id}.md`
 const url = absoluteUrl(`/${post.id}`)
 const crumbs = blogBreadcrumbs(post, tag)
+const neighbors = seriesNeighbors(post, posts)
 ---
 
 <Layout
   title={post.data.title}
   description={post.data.description}
-  image={`${Astro.url.origin}/${post.id}/opengraph-image.png`}
+  image={`${websiteUrl}/${post.id}/opengraph-image.png`}
   imageAlt={post.data.title}
   markdownUrl={markdownUrl}
   jsonLd={blogPostingJsonLd(post, tag)}
@@ -64,7 +73,7 @@ const crumbs = blogBreadcrumbs(post, tag)
   article={{
     authors: [authorFullName],
     publishedTime,
-    modifiedTime: publishedTime,
+    modifiedTime,
     tags: [tag.data.title],
   }}
 >
@@ -95,7 +104,24 @@ const crumbs = blogBreadcrumbs(post, tag)
               }).format(post.data.date)
             }
           </time>
-          <meta itemprop="dateModified" content={post.data.date.toISOString()} />
+          {
+            showUpdated ? (
+              <span class="before:px-2 before:font-serif before:leading-[1] before:content-['·']">
+                Updated{' '}
+                <time datetime={modifiedDate.toISOString()} itemprop="dateModified">
+                  {
+                    new Intl.DateTimeFormat("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    }).format(modifiedDate)
+                  }
+                </time>
+              </span>
+            ) : (
+              <meta itemprop="dateModified" content={modifiedDate.toISOString()} />
+            )
+          }
         </span>
         <span class="before:px-2 before:font-serif before:leading-[1] before:content-['·']">
           {minute_to_read}
@@ -127,6 +153,17 @@ const crumbs = blogBreadcrumbs(post, tag)
         )
       }
     </header>
+    {
+      neighbors && (
+        <div class="grid grid-cols-canvas">
+          <SeriesNav
+            seriesId={neighbors.series.id}
+            previous={neighbors.previous}
+            next={neighbors.next}
+          />
+        </div>
+      )
+    }
     <TableOfContents {headings} />
     <BlogStickyHeader {post} />
     <Prose as="div" itemprop="articleBody">
@@ -141,7 +178,15 @@ const crumbs = blogBreadcrumbs(post, tag)
         <Container size="tight" class="mx-auto">
           <h2 class="mb-4 text-xl font-extrabold dark:text-white">
             {
-              relatedAreSameTag ? (
+              relatedAreSameSeries && neighbors ? (
+                <>
+                  More{' '}
+                  <a href={neighbors.series.path} class="text-orange-400 hover:text-orange-300">
+                    {neighbors.series.title}
+                  </a>{' '}
+                  posts
+                </>
+              ) : relatedAreSameTag ? (
                 <>
                   More{' '}
                   <a href={`/tag/${tag.id}`} class="text-orange-400 hover:text-orange-300">
@@ -156,7 +201,7 @@ const crumbs = blogBreadcrumbs(post, tag)
           </h2>
           <div class="divide-y divide-slate-200 dark:divide-neutral-700">
             {suggestions.map((post) => (
-              <BlogRow {post} />
+              <BlogRow {post} heading="h3" />
             ))}
           </div>
         </Container>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -71,7 +71,9 @@ const markdownUrl = `${websiteUrl}/index.md`
             {year}
           </h2>
           <div class="divide-y divide-slate-200 dark:divide-neutral-700">
-            {postsByYear.get(year)!.map((post) => <BlogRow {post} itemprop="blogPost" />)}
+            {postsByYear.get(year)!.map((post) => (
+              <BlogRow {post} heading="h3" itemprop="blogPost" />
+            ))}
           </div>
         </Container>
       ))}

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -3,7 +3,8 @@ export const prerender = true
 import { getCollection } from 'astro:content'
 import type { APIRoute } from 'astro'
 import { authorFullName, websiteDescription, websiteTitle, websiteUrl } from '@/lib/content'
-import { pageToMarkdown, postToMarkdown } from '@/lib/to-markdown'
+import { postsInSeries, SERIES } from '@/lib/series'
+import { pageToMarkdown, postToMarkdown, seriesToMarkdown } from '@/lib/to-markdown'
 
 export const GET: APIRoute = async () => {
   const [posts, pages] = await Promise.all([
@@ -28,6 +29,16 @@ export const GET: APIRoute = async () => {
   for (const page of pages) {
     sections.push('', `<!-- ${websiteUrl}/${page.id} -->`, '', pageToMarkdown(page), '')
   }
+
+  const urlParsing = SERIES['url-parsing']
+  const seriesPosts = postsInSeries(posts, urlParsing.id)
+  sections.push(
+    '',
+    `<!-- ${websiteUrl}${urlParsing.path} -->`,
+    '',
+    seriesToMarkdown(urlParsing.title, urlParsing.description, urlParsing.path, seriesPosts),
+    '',
+  )
 
   for (const post of posts) {
     sections.push('', `<!-- ${websiteUrl}/${post.id} -->`, '', postToMarkdown(post), '')

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -35,6 +35,7 @@ export const GET: APIRoute = async () => {
     '## Pages',
     '',
     `- [About](${websiteUrl}/about.md): Background, work history, and open source contributions by ${authorFullName}`,
+    `- [URL parsing](${websiteUrl}/url-parsing.md): Series on WHATWG URL parsing, Ada, Node.js, and SIMD`,
     `- [Press](${websiteUrl}/press.md): Articles, interviews, presentations, and podcast appearances featuring ${authorFullName}`,
     `- [Newsletter](${websiteUrl}/newsletter.md): Subscribe to get new posts delivered by email`,
     `- [Home index](${websiteUrl}/index.md): Full list of published posts in markdown`,

--- a/src/pages/url-parsing.astro
+++ b/src/pages/url-parsing.astro
@@ -1,0 +1,56 @@
+---
+import { getCollection } from 'astro:content'
+import BlogRow from '@/components/BlogRow.astro'
+import Breadcrumbs from '@/components/Breadcrumbs.astro'
+import MarkdownLink from '@/components/MarkdownLink.astro'
+import Container from '@/components/ui/Container.astro'
+import Layout from '@/layouts/Layout.astro'
+import { websiteUrl } from '@/lib/content'
+import { seriesBreadcrumbs, seriesCollectionJsonLd } from '@/lib/schema'
+import { postsInSeries, SERIES } from '@/lib/series'
+
+const series = SERIES['url-parsing']
+const allPosts = await getCollection('blog', ({ data }) => data.status === 'published')
+const posts = postsInSeries(allPosts, series.id)
+const markdownUrl = `${websiteUrl}${series.path}.md`
+const crumbs = seriesBreadcrumbs(series.title, series.path)
+---
+
+<Layout
+  title={series.title}
+  description={series.description}
+  markdownUrl={markdownUrl}
+  jsonLd={seriesCollectionJsonLd(series.path, series.title, series.description, posts)}
+>
+  <section itemscope itemtype="https://schema.org/CollectionPage" itemid={`${websiteUrl}${series.path}`}>
+    <link itemprop="url" href={`${websiteUrl}${series.path}`} />
+    <Container size="tight" class="mx-auto -mt-6 flex flex-col gap-8 px-[4vw] text-center">
+      <Breadcrumbs items={crumbs} />
+      <h1 class="text-2xl font-extrabold text-orange-400" itemprop="name">{series.title}</h1>
+      <div class="leading-6 dark:text-white" itemprop="description">{series.description}</div>
+      <MarkdownLink href={markdownUrl} />
+    </Container>
+
+    <div
+      class="py-14"
+      itemprop="mainEntity"
+      itemscope
+      itemtype="https://schema.org/ItemList"
+    >
+      <meta itemprop="numberOfItems" content={String(posts.length)} />
+      <Container
+        size="tight"
+        class="mx-auto divide-y divide-slate-200 px-[4vw] dark:divide-neutral-700"
+      >
+        {
+          posts.map((post, index) => (
+            <div itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+              <meta itemprop="position" content={String(index + 1)} />
+              <BlogRow {post} heading="h2" itemprop="item" />
+            </div>
+          ))
+        }
+      </Container>
+    </div>
+  </section>
+</Layout>

--- a/src/pages/url-parsing.md.ts
+++ b/src/pages/url-parsing.md.ts
@@ -1,0 +1,18 @@
+export const prerender = true
+
+import { getCollection } from 'astro:content'
+import type { APIRoute } from 'astro'
+import { websiteUrl } from '@/lib/content'
+import { postsInSeries, SERIES } from '@/lib/series'
+import { markdownResponse, seriesToMarkdown } from '@/lib/to-markdown'
+
+export const GET: APIRoute = async () => {
+  const series = SERIES['url-parsing']
+  const allPosts = await getCollection('blog', ({ data }) => data.status === 'published')
+  const posts = postsInSeries(allPosts, series.id)
+
+  return markdownResponse(
+    seriesToMarkdown(series.title, series.description, series.path, posts),
+    `${websiteUrl}${series.path}`,
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
---
type: feature
intent: Rank the URL-parsing cluster and ship honest freshness plus query-shaped snippets
app-source-changed: true
constraints: typescript@6, markdown-processor: unified
verify:
  - node --run lint
  - node --run build
preview:
---

## Summary

Follow-up to [#215](https://github.com/anonrig/yagiz.co/pull/215) and [#216](https://github.com/anonrig/yagiz.co/pull/216). Markup is no longer the limiter. This slice adds the ranking-adjacent work that was left:

- Optional `updated` frontmatter, used for `dateModified`, `article:modified_time`, sitemap `lastmod`, and a visible “Updated …” line when it differs from the publish date. No post sets `updated` yet — only real body edits should.
- `/url-parsing` hub for the Ada / WHATWG / SIMD posts. Series nav on those posts, related posts prefer the series, footer links to the hub, JSON-LD `isPartOf` the collection.
- Diary-style meta descriptions rewritten to a concrete claim. Thin tag intros (experimental, database, personal) expanded.
- Prev/next footer shows titles, not only arrows. Home listing uses `h3` under year `h2`s.
- Twitter card dimensions match the 1200×600 OG images. Blog hero `alt` is required. MDX images pass intrinsic width/height.

## Non-goals

- No extra schema.org types (SearchAction, FAQ, HowTo)
- No rewriting post bodies or inventing 2026 benchmark updates
- No `updated` dates on description-only edits
- No `hreflang` changes
- Rankings still depend on crawl, links, and content

## Test plan

- [ ] `node --run lint`
- [ ] `node --run build`
- [ ] `/url-parsing` lists the series in chronological order and links to each post
- [ ] A series post (e.g. `/release-of-ada-v4`) shows “Part of URL parsing” with prev/next titles
- [ ] Related block on a series post is “More URL parsing posts”
- [ ] Post footer prev/next shows visible titles
- [ ] Home year headings stay `h2`; post titles are `h3`
- [ ] Footer includes “URL parsing”
- [ ] Markdown / Worker / sitemap:
  - [ ] `GET /llms.txt` → `200 text/plain` and lists `/url-parsing.md`
  - [ ] `GET /llms-full.txt` → `200 text/plain`
  - [ ] `GET /url-parsing.md` → YAML frontmatter + `X-Robots-Tag: noindex`
  - [ ] `Accept: text/markdown` on `/url-parsing` → `text/markdown` + `Vary: Accept` (no noindex)
  - [ ] HTML has `Link: rel="alternate"; type="text/markdown"`
  - [ ] `Accept: application/pdf` → `406`
  - [ ] sitemap lists `/url-parsing` and HTML only (no `.md` / `llms*.txt`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

