### PR TITLE
Adopt Astro 7 Sätteri, disable sessions, enable content Intellisense

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,12 +87,22 @@ must include the LLM surfaces: `/llms.txt`, `/llms-full.txt`, `Accept: text/mark
   that was the Astro v4 location). All collections must use loaders (e.g. `glob()`).
 - **`z` (Zod)**: import from `astro/zod`, not from `astro:content`.
 - **Rust compiler**: default in Astro 7 — do not set `experimental.rustCompiler`.
-- **Markdown/MDX plugins**: use `markdown.processor: unified({...})` from
-  `@astrojs/markdown-remark`. Plugins on `mdx({ remarkPlugins, rehypePlugins })` are
-  deprecated. This project stays on unified (not Sätteri) for rehype-slug / autolink
-  headings. Code fences use Astro's built-in Shiki (`markdown.shikiConfig`).
+- **Markdown/MDX**: Astro 7's default Sätteri processor (`markdown.processor: satteri()`).
+  Heading permalinks are a Sätteri hast plugin (`src/lib/satteri-autolink.ts`) after
+  `satteriHeadingIdsPlugin()`. Do not re-add `@astrojs/markdown-remark` / remark /
+  rehype plugins unless a plugin has no Sätteri equivalent. Code fences use Astro's
+  built-in Shiki (`markdown.shikiConfig`). Plugins on `mdx({ remarkPlugins })` are
+  deprecated.
+- **Sessions**: `session: false`. This site does not use `Astro.session`. Leave it
+  off so the Cloudflare adapter does not wire the `SESSION` KV binding as a driver.
 - **`compressHTML`**: Astro 7 defaults to `'jsx'` whitespace rules; this project sets
   `compressHTML: true` to keep previous HTML-aware spacing.
+- **Advanced Routing (`src/fetch.ts`)**: do not add. Accept negotiation and SEO
+  headers stay in `src/worker.ts` via `@astrojs/cloudflare/handler`, which also
+  handles the prerender protocol that `cf()` + `astro()` does not.
+- **Incremental static builds**: do not enable `experimental.incrementalBuild`.
+  Post pages also render related posts / series neighbors, so `cacheKey: entry.digest`
+  would serve stale sidebars.
 
 ## Cloudflare adapter (v14)
 
@@ -163,3 +173,7 @@ Do **not** use `fontProviders.fontsource()` — it requires outbound HTTPS to
 | `open`                        | Was unused                                                              |
 | `rehype-pretty-code`          | Astro built-in Shiki + `@shikijs/transformers`                          |
 | `@biomejs/biome`              | Oxlint + Oxfmt                                                          |
+| `@astrojs/markdown-remark`    | Sätteri (`@astrojs/markdown-satteri`)                                   |
+| `rehype-slug`                 | `satteriHeadingIdsPlugin()`                                             |
+| `rehype-autolink-headings`    | `src/lib/satteri-autolink.ts`                                           |
+| `remark-gfm`                  | Sätteri built-in GFM                                                    |

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,17 +1,14 @@
 import cloudflare from '@astrojs/cloudflare'
 import { cacheCloudflare } from '@astrojs/cloudflare/cache'
-import { unified } from '@astrojs/markdown-remark'
+import { satteri, satteriHeadingIdsPlugin } from '@astrojs/markdown-satteri'
 import mdx from '@astrojs/mdx'
 import sitemap from '@astrojs/sitemap'
 import { transformerMetaHighlight, transformerMetaWordHighlight } from '@shikijs/transformers'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig, fontProviders } from 'astro/config'
-import rehypeAutolinkHeadings from 'rehype-autolink-headings'
-import type { Options as RehypeAutolinkHeadingsOptions } from 'rehype-autolink-headings'
-import rehypeSlug from 'rehype-slug'
-import remarkGfm from 'remark-gfm'
 
 import { websiteUrl } from './src/lib/content.ts'
+import { autolinkHeadingsPlugin } from './src/lib/satteri-autolink.ts'
 import {
   transformerEmptyLine,
   transformerInlineStylesToClasses,
@@ -43,22 +40,19 @@ export default defineConfig({
         transformerInlineStylesToClasses(),
       ],
     },
-    processor: unified({
-      gfm: true,
-      remarkPlugins: [remarkGfm],
-      rehypePlugins: [
-        rehypeSlug,
-        [
-          rehypeAutolinkHeadings,
-          {
-            properties: {
-              className: ['anchor'],
-              ariaLabel: 'Link to this heading',
-            },
-          } satisfies RehypeAutolinkHeadingsOptions,
-        ],
-      ],
+    // Sätteri is Astro 7's default Rust markdown pipeline. Heading IDs must
+    // be applied in this user plugin list so autolink can read them; Astro
+    // also appends the same heading-id plugin after user plugins.
+    processor: satteri({
+      hastPlugins: [satteriHeadingIdsPlugin(), autolinkHeadingsPlugin()],
     }),
+  },
+  // Cloudflare adapter would otherwise wire the unused SESSION KV as a
+  // default session driver and keep the session runtime in the Worker bundle.
+  session: false,
+  experimental: {
+    // JSON schemas for blog/page/tag frontmatter in compatible editors.
+    contentIntellisense: true,
   },
   security: {
     csp: {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@astrojs/cloudflare": "^14.2.3",
     "@astrojs/compiler-rs": "^0.3.2",
-    "@astrojs/markdown-remark": "^7.2.4",
     "@astrojs/markdown-satteri": "^0.3.7",
     "@astrojs/mdx": "^7.0.7",
     "@astrojs/sitemap": "^3.7.3",
@@ -31,10 +30,8 @@
     "handlebars": "^4.7.9",
     "mjml": "^5.4.0",
     "node-mailjet": "^6.0.11",
-    "rehype-autolink-headings": "^7.1.0",
-    "rehype-slug": "^6.0.0",
-    "remark-gfm": "^4.0.1",
     "satori": "^0.33.3",
+    "satteri": "^0.10.5",
     "sharp": "^0.35.3",
     "tailwindcss": "^4.3.3",
     "wrangler": "^4.125.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@astrojs/compiler-rs':
         specifier: ^0.3.2
         version: 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
-      '@astrojs/markdown-remark':
-        specifier: ^7.2.4
-        version: 7.2.4
       '@astrojs/markdown-satteri':
         specifier: ^0.3.7
         version: 0.3.7
@@ -59,18 +56,12 @@ importers:
       node-mailjet:
         specifier: ^6.0.11
         version: 6.0.11
-      rehype-autolink-headings:
-        specifier: ^7.1.0
-        version: 7.1.0
-      rehype-slug:
-        specifier: ^6.0.0
-        version: 6.0.0
-      remark-gfm:
-        specifier: ^4.0.1
-        version: 4.0.1
       satori:
         specifier: ^0.33.3
         version: 0.33.3
+      satteri:
+        specifier: ^0.10.5
+        version: 0.10.5
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@26.2.0)
@@ -971,12 +962,6 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
-
-  '@napi-rs/wasm-runtime@1.1.6':
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
 
   '@napi-rs/wasm-runtime@1.2.3':
     resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
@@ -2496,9 +2481,6 @@ packages:
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
 
-  hast-util-heading-rank@3.0.0:
-    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
-
   hast-util-is-element@3.0.0:
     resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
 
@@ -2519,9 +2501,6 @@ packages:
 
   hast-util-to-parse5@8.0.1:
     resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
-
-  hast-util-to-string@3.0.1:
-    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
   hast-util-to-text@4.0.2:
     resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
@@ -3728,17 +3707,11 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
-  rehype-autolink-headings@7.1.0:
-    resolution: {integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==}
-
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
-
-  rehype-slug@6.0.0:
-    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
@@ -5299,13 +5272,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -5530,7 +5496,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.1.5':
@@ -6765,10 +6731,6 @@ snapshots:
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
 
-  hast-util-heading-rank@3.0.0:
-    dependencies:
-      '@types/hast': 3.0.5
-
   hast-util-is-element@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
@@ -6857,10 +6819,6 @@ snapshots:
       space-separated-tokens: 2.0.2
       web-namespaces: 2.0.1
       zwitch: 2.0.4
-
-  hast-util-to-string@3.0.1:
-    dependencies:
-      '@types/hast': 3.0.5
 
   hast-util-to-text@4.0.2:
     dependencies:
@@ -8680,15 +8638,6 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  rehype-autolink-headings@7.1.0:
-    dependencies:
-      '@types/hast': 3.0.5
-      '@ungap/structured-clone': 1.3.3
-      hast-util-heading-rank: 3.0.0
-      hast-util-is-element: 3.0.0
-      unified: 11.0.5
-      unist-util-visit: 5.1.0
-
   rehype-raw@7.0.0:
     dependencies:
       '@types/hast': 3.0.5
@@ -8702,14 +8651,6 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
-
-  rehype-slug@6.0.0:
-    dependencies:
-      '@types/hast': 3.0.5
-      github-slugger: 2.0.0
-      hast-util-heading-rank: 3.0.0
-      hast-util-to-string: 3.0.1
-      unist-util-visit: 5.1.0
 
   rehype-stringify@10.0.1:
     dependencies:

--- a/src/lib/satteri-autolink.ts
+++ b/src/lib/satteri-autolink.ts
@@ -1,0 +1,41 @@
+import { defineHastPlugin } from 'satteri'
+import type { HastPluginDefinition } from 'satteri'
+
+/**
+ * Sätteri equivalent of rehype-autolink-headings (`behavior: 'prepend'`).
+ * Astro's heading-id plugin must run first so `id` is already on the node.
+ */
+export function autolinkHeadingsPlugin(): HastPluginDefinition {
+  return defineHastPlugin({
+    name: 'autolink-headings',
+    element: {
+      filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+      visit(node, ctx) {
+        const { id } = node.properties
+        if (typeof id !== 'string' || id.length === 0) {
+          return
+        }
+
+        ctx.prependChild(node, {
+          type: 'element',
+          tagName: 'a',
+          properties: {
+            href: `#${id}`,
+            className: ['anchor'],
+            ariaLabel: 'Link to this heading',
+          },
+          children: [
+            {
+              type: 'element',
+              tagName: 'span',
+              properties: {
+                className: ['icon', 'icon-link'],
+              },
+              children: [],
+            },
+          ],
+        })
+      },
+    },
+  })
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
---
type: chore
intent: Use Astro 7 features this site was not already using — Sätteri markdown, session: false, and experimental content Intellisense. Stay on TypeScript 6. Do not replace the Cloudflare worker with src/fetch.ts.
app-source-changed: true
constraints: typescript@6, markdown-processor: satteri, session: false, no src/fetch.ts, no experimental.incrementalBuild, compressHTML: true, oxfmt cannot format .astro
verify:
  - node --run lint
  - node --run build
preview: https://cursor-astro-7-features-b6e5-yagiz.nizipli.workers.dev
---

## Summary

The site is already on Astro 7.2.4. This PR adopts the remaining 7.x features that help, and leaves the rest alone.

**Adopted**

- **Sätteri** is now the markdown/MDX processor (Astro 7 default, Rust pipeline). Heading permalinks stay: `satteriHeadingIdsPlugin()` then `src/lib/satteri-autolink.ts` (same `.anchor` / `aria-label` / `icon-link` markup as rehype-autolink-headings). GFM and Shiki transformers are unchanged. Heading HTML on `/about`, `/cordova-react-native-swift`, and `/state-of-url-parsing-2025` matches the pre-Sätteri build.
- **`session: false`** (Astro 7.2). `@astrojs/cloudflare` auto-enables KV sessions whenever a `SESSION` binding exists. Nothing in this repo uses `Astro.session`, so the adapter was still bundling the session runtime. The KV namespace stays in `wrangler.toml`; Astro just does not use it.
- **`experimental.contentIntellisense`** writes collection JSON schemas for editor completion on blog/page/tag frontmatter.

Removed unused unified stack: `@astrojs/markdown-remark`, `rehype-slug`, `rehype-autolink-headings`, `remark-gfm`. Added a direct `satteri` dependency for the hast plugin API.

**Already in use (no change)**

Vite 8 / Rolldown, Rust `.astro` compiler, queued rendering, `cacheCloudflare()` + `routeRules`, fonts API (`fontProviders.local()`, `display: 'optional'`), CSP `style-src-attr`, `prefetch: true`, `compressHTML: true`.

## Non-goals

- Do not add `src/fetch.ts` or replace `handle()` with `cf()` + `astro()`. The custom worker owns Accept negotiation / SEO headers, and `handle()` implements the prerender protocol that Advanced Routing's `cf()` helper does not.
- Do not enable `experimental.incrementalBuild`. Post pages also render related posts and series neighbors, so `cacheKey: entry.digest` would serve stale sidebars.
- Do not switch `compressHTML` to the v7 `'jsx'` default.
- Do not upgrade TypeScript to 7.
- Do not enable `options.typeCheck` on oxlint.
- Do not delete the `SESSION` KV namespace.
- Do not adopt View Transitions / `ClientRouter`, Astro Actions, `paginate().format`, `deferRender`, or `experimental.collectionStorage` (small collections).
- Do not change Worker markdown / sitemap / LLM *behavior*.

## Test plan

- [x] `node --run lint`
- [x] `node --run build`
- [x] Heading permalinks on `/about` and a blog post: `#` appears on hover/focus, `id` matches TOC slugs
- [x] Compare heading HTML to pre-Sätteri output (ids + `.anchor` + `aria-label`) — identical on about, cordova, and 2025 URL-parsing posts
- [x] Built `/llms.txt` is `text/plain` content
- [x] Built `/llms-full.txt` exists (full post dump)
- [x] Built `/{page}.md` has YAML frontmatter
- [x] sitemap-0.xml lists HTML only (no `.md` / `llms*.txt`)
- [ ] Preview Worker: `Accept: text/markdown` on an HTML URL → `Content-Type: text/markdown` + `Vary: Accept` (worker unchanged)
- [ ] Preview Worker: HTML response has `Link: rel="alternate"; type="text/markdown"`
- [ ] Preview Worker: `Accept: application/pdf` → `406`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

