### PR TITLE
Harden forms, add CI tests, and finish leftover cleanups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
       interval: monthly
     commit-message:
       prefix: pnpm
+    ignore:
+      - dependency-name: '@biomejs/biome'
+      - dependency-name: '@astrojs/compiler-rs'
+        versions: ['>=0.4.0']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+name: Build
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test
+      - run: pnpm run build

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -386,6 +386,13 @@
       "rules": {
         "typescript/triple-slash-reference": "off"
       }
+    },
+    {
+      "files": ["**/*.test.ts"],
+      "rules": {
+        "typescript/explicit-function-return-type": "off",
+        "typescript/explicit-module-boundary-types": "off"
+      }
     }
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -391,7 +391,8 @@
       "files": ["**/*.test.ts"],
       "rules": {
         "typescript/explicit-function-return-type": "off",
-        "typescript/explicit-module-boundary-types": "off"
+        "typescript/explicit-module-boundary-types": "off",
+        "typescript/no-floating-promises": "off"
       }
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,13 @@ node --run preview        # wrangler dev (Cloudflare Workers local preview)
 node --run deploy         # build && wrangler deploy
 node --run lint           # wrangler types && astro sync && oxlint . && oxfmt --check
 node --run lint-fix       # wrangler types && astro sync && oxlint --fix . && oxfmt
+node --run test           # node:test for src/lib/*.test.ts (no Vitest)
 node --run cli            # interactive CLI for blog/newsletter tasks
 ```
 
 Always run `node --run build` before marking a task complete. It runs type generation,
-type checking, and the full Astro build in one step.
+type checking, and the full Astro build in one step. CI runs `pnpm run test` then
+`pnpm run build` in `.github/workflows/build.yml`.
 
 ## Stack
 
@@ -150,6 +152,13 @@ wrangler d1 migrations apply newsletter --local    # local dev
 Add new schema changes as `migrations/0002_*.sql`, `migrations/0003_*.sql`, etc.
 Never edit existing migration files.
 
+`/api/contact` and `/api/newsletter` share helpers in `src/lib/form-api.ts` and
+`src/lib/rate-limit.ts`. Invalid JSON is `400`. A filled `company` honeypot is a
+fake `200` and does not increment the limiter. Real email / length checks run
+before D1 or email send. Contact HTML escapes `email` / `message` and strips
+CR/LF from `subject`. Rate limit is 5 requests / 10 minutes / IP via
+`caches.default` (fail open). Do not add Turnstile or Vitest.
+
 ## Fonts
 
 The site uses the Mulish variable font. It is self-hosted via Astro's built-in fonts API
@@ -177,3 +186,4 @@ Do **not** use `fontProviders.fontsource()` — it requires outbound HTTPS to
 | `rehype-slug`                 | `satteriHeadingIdsPlugin()`                                             |
 | `rehype-autolink-headings`    | `src/lib/satteri-autolink.ts`                                           |
 | `remark-gfm`                  | Sätteri built-in GFM                                                    |
+| `vitest`                      | `node:test` (`src/lib/*.test.ts`)                                       |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,10 +153,11 @@ Add new schema changes as `migrations/0002_*.sql`, `migrations/0003_*.sql`, etc.
 Never edit existing migration files.
 
 `/api/contact` and `/api/newsletter` share helpers in `src/lib/form-api.ts` and
-`src/lib/rate-limit.ts`. Invalid JSON is `400`. A filled `company` honeypot is a
-fake `200` and does not increment the limiter. Real email / length checks run
-before D1 or email send. Contact HTML escapes `email` / `message` and strips
-CR/LF from `subject`. Rate limit is 5 requests / 10 minutes / IP via
+`src/lib/rate-limit.ts`. Invalid JSON is `400`. A filled `website_url` honeypot
+is a fake `200` and does not increment the limiter (do not name it `company` —
+password managers autofill that). Real email / length checks run before D1 or
+email send. Contact HTML escapes `email` / `message` and strips CR/LF from
+`subject`. Rate limit is a fixed 5 requests / 10 minutes / IP via
 `caches.default` (fail open). Do not add Turnstile or Vitest.
 
 ## Fonts

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -104,6 +104,9 @@ export default defineConfig({
     // that are not compatible with Cloudflare's workerd runtime.
     prerenderEnvironment: 'node',
   }),
+  image: {
+    responsiveStyles: true,
+  },
   trailingSlash: 'never',
   prefetch: true,
   redirects: {

--- a/cli.mjs
+++ b/cli.mjs
@@ -8,7 +8,6 @@ const intention = await select({
   options: [
     { label: 'Create a blog post', value: 'blog' },
     { label: 'Send an email', value: 'email' },
-    { label: 'Update sponsorships', value: 'sponsorship' },
   ],
 })
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "astro": "astro",
     "lint": "wrangler types && astro sync && oxlint . && oxfmt --check",
     "lint-fix": "wrangler types && astro sync && oxlint --fix . && oxfmt",
+    "test": "node --experimental-strip-types --test src/lib/*.test.ts",
     "cli": "node --no-warnings ./cli.mjs",
     "presentation": "marp --allow-local-files -s ./presentations"
   },

--- a/src/components/BlogFooter.astro
+++ b/src/components/BlogFooter.astro
@@ -1,6 +1,6 @@
 ---
 import { Image } from 'astro:assets'
-import { getCollection } from 'astro:content'
+import type { CollectionEntry } from 'astro:content'
 
 import { ArrowLeft, ArrowRight } from '@lucide/astro'
 import authorImg from '@/assets/author-image.png'
@@ -10,11 +10,10 @@ import { schemaIds } from '@/lib/schema'
 
 interface Props {
   index: number
+  posts: CollectionEntry<'blog'>[]
 }
 
-const { index } = Astro.props
-const collected = await getCollection('blog', ({ data }) => data.status === 'published')
-const posts = collected.toSorted((a, b) => b.data.date.getTime() - a.data.date.getTime())
+const { index, posts }: Props = Astro.props
 const next = index === 0 ? undefined : posts.at(index - 1)
 const previous = index === posts.length - 1 ? undefined : posts.at(index + 1)
 ---
@@ -56,6 +55,7 @@ const previous = index === posts.length - 1 ? undefined : posts.at(index + 1)
           alt={authorFullName}
           width={50}
           height={50}
+          layout="fixed"
           class="rounded-full"
           itemprop="image"
         />

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -1,4 +1,4 @@
-<form class="grid grid-cols-canvas [&>*]:col-main gap-y-4 mt-6">
+<form class="relative grid grid-cols-canvas [&>*]:col-main gap-y-4 mt-6">
   <div
     id='success-message'
     role="status"
@@ -57,6 +57,11 @@
     />
   </div>
 
+  <div class="absolute -left-[10000px] top-auto h-px w-px overflow-hidden" aria-hidden="true">
+    <label for="company">Company</label>
+    <input id="company" name="company" type="text" tabindex="-1" autocomplete="off" />
+  </div>
+
   <div>
     <button
       id='submit'
@@ -82,6 +87,7 @@
   const subject = requireEl('#subject', HTMLInputElement)
   const email = requireEl('#email', HTMLInputElement)
   const message = requireEl('#message', HTMLTextAreaElement)
+  const company = requireEl('#company', HTMLInputElement)
   const successMessage = requireEl('#success-message', HTMLDivElement)
   const errorMessage = requireEl('#error-message', HTMLDivElement)
 
@@ -95,7 +101,12 @@
       const res = await fetch('/api/contact', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email.value, subject: subject.value, message: message.value }),
+        body: JSON.stringify({
+          email: email.value,
+          subject: subject.value,
+          message: message.value,
+          company: company.value,
+        }),
       })
 
       if (!res.ok) {

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -58,8 +58,17 @@
   </div>
 
   <div class="absolute -left-[10000px] top-auto h-px w-px overflow-hidden" aria-hidden="true">
-    <label for="company">Company</label>
-    <input id="company" name="company" type="text" tabindex="-1" autocomplete="off" />
+    <label for="website-url">Website</label>
+    <input
+      id="website-url"
+      name="website_url"
+      type="text"
+      tabindex="-1"
+      autocomplete="off"
+      data-1p-ignore
+      data-lpignore="true"
+      data-form-type="other"
+    />
   </div>
 
   <div>
@@ -87,7 +96,7 @@
   const subject = requireEl('#subject', HTMLInputElement)
   const email = requireEl('#email', HTMLInputElement)
   const message = requireEl('#message', HTMLTextAreaElement)
-  const company = requireEl('#company', HTMLInputElement)
+  const websiteUrl = requireEl('#website-url', HTMLInputElement)
   const successMessage = requireEl('#success-message', HTMLDivElement)
   const errorMessage = requireEl('#error-message', HTMLDivElement)
 
@@ -105,7 +114,7 @@
           email: email.value,
           subject: subject.value,
           message: message.value,
-          company: company.value,
+          website_url: websiteUrl.value,
         }),
       })
 

--- a/src/components/NewsletterForm.astro
+++ b/src/components/NewsletterForm.astro
@@ -1,4 +1,4 @@
-<form class="grid grid-cols-canvas [&>*]:col-main gap-y-4 mt-6">
+<form class="relative grid grid-cols-canvas [&>*]:col-main gap-y-4 mt-6">
   <div
     id='success-message'
     role="status"
@@ -50,6 +50,11 @@
     />
   </div>
 
+  <div class="absolute -left-[10000px] top-auto h-px w-px overflow-hidden" aria-hidden="true">
+    <label for="company">Company</label>
+    <input id="company" name="company" type="text" tabindex="-1" autocomplete="off" />
+  </div>
+
   <div>
     <button
       id='submit'
@@ -74,6 +79,7 @@
   const submit = requireEl('#submit', HTMLButtonElement)
   const name = requireEl('#name', HTMLInputElement)
   const email = requireEl('#email', HTMLInputElement)
+  const company = requireEl('#company', HTMLInputElement)
   const successMessage = requireEl('#success-message', HTMLDivElement)
   const errorMessage = requireEl('#error-message', HTMLDivElement)
 
@@ -87,7 +93,7 @@
       const res = await fetch('/api/newsletter', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ email: email.value, name: name.value }),
+        body: JSON.stringify({ email: email.value, name: name.value, company: company.value }),
       })
 
       if (!res.ok) {

--- a/src/components/NewsletterForm.astro
+++ b/src/components/NewsletterForm.astro
@@ -51,8 +51,17 @@
   </div>
 
   <div class="absolute -left-[10000px] top-auto h-px w-px overflow-hidden" aria-hidden="true">
-    <label for="company">Company</label>
-    <input id="company" name="company" type="text" tabindex="-1" autocomplete="off" />
+    <label for="website-url">Website</label>
+    <input
+      id="website-url"
+      name="website_url"
+      type="text"
+      tabindex="-1"
+      autocomplete="off"
+      data-1p-ignore
+      data-lpignore="true"
+      data-form-type="other"
+    />
   </div>
 
   <div>
@@ -79,7 +88,7 @@
   const submit = requireEl('#submit', HTMLButtonElement)
   const name = requireEl('#name', HTMLInputElement)
   const email = requireEl('#email', HTMLInputElement)
-  const company = requireEl('#company', HTMLInputElement)
+  const websiteUrl = requireEl('#website-url', HTMLInputElement)
   const successMessage = requireEl('#success-message', HTMLDivElement)
   const errorMessage = requireEl('#error-message', HTMLDivElement)
 
@@ -93,7 +102,11 @@
       const res = await fetch('/api/newsletter', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ email: email.value, name: name.value, company: company.value }),
+        body: JSON.stringify({
+          email: email.value,
+          name: name.value,
+          website_url: websiteUrl.value,
+        }),
       })
 
       if (!res.ok) {

--- a/src/components/mdx/Image.astro
+++ b/src/components/mdx/Image.astro
@@ -8,7 +8,7 @@ interface Props {
   class?: string
 }
 
-const { src, class: className, alt } = Astro.props
+const { src, class: className, alt }: Props = Astro.props
 
 const images = import.meta.glob<{ default: ImageMetadata }>('/src/assets/**/*')
 
@@ -34,6 +34,7 @@ const imageClass = [
       {alt}
       width={asset.width}
       height={asset.height}
+      layout="constrained"
       class:list={imageClass}
     />
   ) : (

--- a/src/components/ui/Container.astro
+++ b/src/components/ui/Container.astro
@@ -5,7 +5,7 @@ interface Props {
   size?: 'wide' | 'tight'
 }
 
-const { size = 'wide', as = 'div', class: className } = Astro.props
+const { size = 'wide', as = 'div', class: className }: Props = Astro.props
 const Component = as
 ---
 

--- a/src/components/ui/Figure.astro
+++ b/src/components/ui/Figure.astro
@@ -9,28 +9,30 @@ interface Props {
   itemprop?: string
 }
 
-const {props} = Astro
+const { caption, src, alt, itemprop }: Props = Astro.props
 ---
 <figure
   class="mt-6 col-wide"
   itemscope
   itemtype="https://schema.org/ImageObject"
-  itemprop={props.itemprop}
+  itemprop={itemprop}
 >
   <Image
-    src={props.src}
-    alt={props.alt}
+    src={src}
+    alt={alt}
     width={920}
+    layout="constrained"
+    fit="cover"
     loading="eager"
     fetchpriority="high"
     class="duration-300 ease-in-out bg-gray-100 dark:bg-gray-900 aspect-[2/1] w-full object-cover object-center"
     itemprop="contentUrl"
   />
-  <meta itemprop="name" content={props.alt} />
+  <meta itemprop="name" content={alt} />
   {
-    props.caption && (
+    caption && (
       <figcaption class="mt-4 text-sm text-neutral-400" itemprop="caption">
-        {props.caption}
+        {caption}
       </figcaption>
     )
   }

--- a/src/components/ui/Prose.astro
+++ b/src/components/ui/Prose.astro
@@ -4,7 +4,7 @@ interface Props {
   as?: 'article' | 'div'
 }
 
-const { itemprop, as: Tag = 'article' } = Astro.props
+const { itemprop, as: Tag = 'article' }: Props = Astro.props
 ---
 
 <Tag

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,3 +1,2 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
-/// <reference types="../.astro/types.ts" />

--- a/src/lib/accept.test.ts
+++ b/src/lib/accept.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  isAgentOnlyPath,
+  isImmutableAsset,
+  markdownPath,
+  preferredType,
+  shouldSkipNegotiation,
+} from './accept.ts'
+
+test('preferredType defaults to the first produced type without Accept', () => {
+  assert.equal(preferredType(null, ['text/html', 'text/markdown']), 'text/html')
+})
+
+test('preferredType picks markdown when it is preferred', () => {
+  assert.equal(
+    preferredType('text/markdown, text/html;q=0.8', ['text/html', 'text/markdown']),
+    'text/markdown',
+  )
+})
+
+test('preferredType returns null when every candidate is q=0', () => {
+  assert.equal(
+    preferredType('text/html;q=0, text/markdown;q=0', ['text/html', 'text/markdown']),
+    null,
+  )
+})
+
+test('preferredType treats application/pdf as unacceptable for html/markdown', () => {
+  assert.equal(preferredType('application/pdf', ['text/html', 'text/markdown']), null)
+})
+
+test('preferredType honors */* as a match', () => {
+  assert.equal(preferredType('*/*', ['text/html', 'text/markdown']), 'text/html')
+})
+
+test('markdownPath maps HTML paths to .md siblings', () => {
+  assert.equal(markdownPath('/'), '/index.md')
+  assert.equal(markdownPath('/about'), '/about.md')
+  assert.equal(markdownPath('/about/'), '/about.md')
+  assert.equal(markdownPath('/tag/performance'), '/tag/performance.md')
+})
+
+test('isAgentOnlyPath marks markdown and llms endpoints', () => {
+  assert.equal(isAgentOnlyPath('/about.md'), true)
+  assert.equal(isAgentOnlyPath('/llms.txt'), true)
+  assert.equal(isAgentOnlyPath('/llms-full.txt'), true)
+  assert.equal(isAgentOnlyPath('/about'), false)
+})
+
+test('shouldSkipNegotiation skips APIs, assets, and static files', () => {
+  assert.equal(shouldSkipNegotiation('/api/contact'), true)
+  assert.equal(shouldSkipNegotiation('/_astro/foo.css'), true)
+  assert.equal(shouldSkipNegotiation('/about.md'), true)
+  assert.equal(shouldSkipNegotiation('/about'), false)
+})
+
+test('isImmutableAsset covers hashed Astro assets', () => {
+  assert.equal(isImmutableAsset('/_astro/family.hash.webp'), true)
+  assert.equal(isImmutableAsset('/about'), false)
+})

--- a/src/lib/form-api.test.ts
+++ b/src/lib/form-api.test.ts
@@ -42,7 +42,7 @@ test('field validators match the public form minimums', () => {
   assert.equal(validateMessage('too short'), false)
 })
 
-test('isHoneypot treats any filled company field as a bot', () => {
+test('isHoneypot treats any filled website_url field as a bot', () => {
   assert.equal(isHoneypot('https://spam.example'), true)
   assert.equal(isHoneypot(''), false)
 })

--- a/src/lib/form-api.test.ts
+++ b/src/lib/form-api.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  escapeHtml,
+  isEmail,
+  isHoneypot,
+  jsonResponse,
+  oneLine,
+  readJsonObject,
+  readString,
+  validateMessage,
+  validateName,
+  validateSubject,
+} from './form-api.ts'
+
+test('escapeHtml encodes markup used in contact mail', () => {
+  assert.equal(
+    escapeHtml(`<img src=x onerror="alert(1)">&'"'"`),
+    '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;&amp;&#39;&quot;&#39;&quot;',
+  )
+})
+
+test('oneLine strips header-injection characters from subjects', () => {
+  assert.equal(oneLine('Hello\r\nBcc: evil@example.com'), 'Hello Bcc: evil@example.com')
+})
+
+test('isEmail accepts and rejects obvious addresses', () => {
+  assert.equal(isEmail('yagiz@nizipli.com'), true)
+  assert.equal(isEmail('not-an-email'), false)
+  assert.equal(isEmail('a@b'), false)
+  assert.equal(isEmail('foo@bar..com'), false)
+  assert.equal(isEmail(''), false)
+})
+
+test('field validators match the public form minimums', () => {
+  assert.equal(validateName('Ya'), true)
+  assert.equal(validateName('Y'), false)
+  assert.equal(validateSubject('Hello'), true)
+  assert.equal(validateSubject('Hey'), false)
+  assert.equal(validateMessage('x'.repeat(20)), true)
+  assert.equal(validateMessage('too short'), false)
+})
+
+test('isHoneypot treats any filled company field as a bot', () => {
+  assert.equal(isHoneypot('https://spam.example'), true)
+  assert.equal(isHoneypot(''), false)
+})
+
+test('readJsonObject rejects invalid and non-object bodies', async () => {
+  assert.equal(await readJsonObject(new Request('https://yagiz.co', { method: 'POST' })), null)
+  assert.equal(
+    await readJsonObject(
+      new Request('https://yagiz.co', {
+        method: 'POST',
+        body: '[]',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ),
+    null,
+  )
+
+  const object = await readJsonObject(
+    new Request('https://yagiz.co', {
+      method: 'POST',
+      body: JSON.stringify({ email: ' a@b.co ' }),
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+  assert.ok(object)
+  assert.equal(readString(object, 'email'), 'a@b.co')
+  assert.equal(readString(object, 'missing'), '')
+})
+
+test('jsonResponse is JSON and uncached', async () => {
+  const response = jsonResponse(429, 'Too many requests. Please try again later.')
+  assert.equal(response.status, 429)
+  assert.equal(response.headers.get('Cache-Control'), 'no-store')
+  assert.deepEqual(await response.json(), {
+    status: 429,
+    message: 'Too many requests. Please try again later.',
+  })
+})

--- a/src/lib/form-api.ts
+++ b/src/lib/form-api.ts
@@ -1,0 +1,68 @@
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u
+const EMAIL_MAX = 254
+const NAME_MAX = 200
+const SUBJECT_MAX = 200
+const MESSAGE_MAX = 10_000
+
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+export function oneLine(value: string): string {
+  return value.replaceAll(/[\r\n\0]/gu, ' ').trim()
+}
+
+export function isEmail(value: string): boolean {
+  return value.length >= 6 && value.length <= EMAIL_MAX && EMAIL_RE.test(value) && !value.includes('..')
+}
+
+export function isHoneypot(value: string): boolean {
+  return value.length > 0
+}
+
+export function jsonResponse(status: number, message: string): Response {
+  return Response.json(
+    { status, message },
+    {
+      status,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    },
+  )
+}
+
+export async function readJsonObject(request: Request): Promise<Record<string, unknown> | null> {
+  try {
+    const body: unknown = await request.json()
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+      return null
+    }
+    return body
+  } catch {
+    return null
+  }
+}
+
+export function readString(body: Record<string, unknown>, key: string): string {
+  const value = body[key]
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export function validateName(value: string): boolean {
+  return value.length >= 2 && value.length <= NAME_MAX
+}
+
+export function validateSubject(value: string): boolean {
+  return value.length >= 5 && value.length <= SUBJECT_MAX
+}
+
+export function validateMessage(value: string): boolean {
+  return value.length >= 20 && value.length <= MESSAGE_MAX
+}

--- a/src/lib/form-api.ts
+++ b/src/lib/form-api.ts
@@ -40,13 +40,14 @@ export function jsonResponse(status: number, message: string): Response {
   )
 }
 
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 export async function readJsonObject(request: Request): Promise<Record<string, unknown> | null> {
   try {
     const body: unknown = await request.json()
-    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
-      return null
-    }
-    return body
+    return isJsonObject(body) ? body : null
   } catch {
     return null
   }

--- a/src/lib/form-api.ts
+++ b/src/lib/form-api.ts
@@ -14,11 +14,13 @@ export function escapeHtml(value: string): string {
 }
 
 export function oneLine(value: string): string {
-  return value.replaceAll(/[\r\n\0]/gu, ' ').trim()
+  return value.replaceAll(/[\r\n\0\s]+/gu, ' ').trim()
 }
 
 export function isEmail(value: string): boolean {
-  return value.length >= 6 && value.length <= EMAIL_MAX && EMAIL_RE.test(value) && !value.includes('..')
+  return (
+    value.length >= 6 && value.length <= EMAIL_MAX && EMAIL_RE.test(value) && !value.includes('..')
+  )
 }
 
 export function isHoneypot(value: string): boolean {

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import type { RateLimitWindow } from './rate-limit.ts'
+import { RATE_LIMIT, RATE_LIMIT_WINDOW_SEC, advanceWindow, parseWindow } from './rate-limit.ts'
+
+test('parseWindow accepts a stored counter and rejects junk', () => {
+  assert.deepEqual(parseWindow({ count: 2, expires: 1000 }), { count: 2, expires: 1000 })
+  assert.equal(parseWindow(null), undefined)
+  assert.equal(parseWindow({ count: '2', expires: 1000 }), undefined)
+  assert.equal(parseWindow(3), undefined)
+})
+
+test('advanceWindow starts a 10-minute window on the first hit', () => {
+  const result = advanceWindow(undefined, 0)
+  assert.equal(result.limited, false)
+  assert.deepEqual(result.next, { count: 1, expires: RATE_LIMIT_WINDOW_SEC * 1000 })
+  assert.equal(result.maxAge, RATE_LIMIT_WINDOW_SEC)
+})
+
+test('advanceWindow keeps the original expiry when incrementing', () => {
+  const first = advanceWindow(undefined, 0)
+  const second = advanceWindow(first.next, 12_000)
+  assert.equal(second.limited, false)
+  assert.equal(second.next.count, 2)
+  assert.equal(second.next.expires, first.next.expires)
+  assert.equal(second.maxAge, RATE_LIMIT_WINDOW_SEC - 12)
+})
+
+test('advanceWindow blocks the sixth request in the same window', () => {
+  let current: RateLimitWindow | undefined
+  let now = 0
+  for (let i = 0; i < RATE_LIMIT; i += 1) {
+    const result = advanceWindow(current, now)
+    assert.equal(result.limited, false)
+    current = result.next
+    now += 1000
+  }
+
+  assert.ok(current)
+  const blocked = advanceWindow(current, now)
+  assert.equal(blocked.limited, true)
+  assert.equal(blocked.next.count, RATE_LIMIT)
+  assert.equal(blocked.next.expires, current.expires)
+})
+
+test('advanceWindow resets after the stored expiry', () => {
+  const spent = { count: RATE_LIMIT, expires: 60_000 }
+  const reset = advanceWindow(spent, 60_000)
+  assert.equal(reset.limited, false)
+  assert.equal(reset.next.count, 1)
+  assert.equal(reset.next.expires, 60_000 + RATE_LIMIT_WINDOW_SEC * 1000)
+})

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,5 +1,43 @@
-const WINDOW_SEC = 600
-const LIMIT = 5
+export const RATE_LIMIT_WINDOW_SEC = 600
+export const RATE_LIMIT = 5
+
+export interface RateLimitWindow {
+  count: number
+  expires: number
+}
+
+export function parseWindow(value: unknown): RateLimitWindow | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined
+  }
+  if (!('count' in value) || !('expires' in value)) {
+    return undefined
+  }
+  const { count, expires } = value
+  if (
+    typeof count !== 'number' ||
+    typeof expires !== 'number' ||
+    !Number.isFinite(count) ||
+    !Number.isFinite(expires)
+  ) {
+    return undefined
+  }
+  return { count, expires }
+}
+
+export function advanceWindow(
+  existing: RateLimitWindow | undefined,
+  now: number,
+): { limited: boolean; next: RateLimitWindow; maxAge: number } {
+  const active = existing !== undefined && existing.expires > now
+  const count = active ? existing.count : 0
+  const expires = active ? existing.expires : now + RATE_LIMIT_WINDOW_SEC * 1000
+  const maxAge = Math.max(1, Math.ceil((expires - now) / 1000))
+  if (count >= RATE_LIMIT) {
+    return { limited: true, next: { count, expires }, maxAge }
+  }
+  return { limited: false, next: { count: count + 1, expires }, maxAge }
+}
 
 interface WorkerCache {
   match: (request: Request) => Promise<Response | undefined>
@@ -41,8 +79,9 @@ function defaultCache(): WorkerCache | undefined {
 }
 
 /**
- * Per-IP sliding window using the Worker Cache API. Fails open if Cache is
- * unavailable (local Node prerender, missing caches).
+ * Per-IP fixed window using the Worker Cache API. Fails open if Cache is
+ * unavailable (local Node prerender, missing caches). The stored `expires`
+ * timestamp is reused so `put` does not restart the 10-minute window.
  */
 export async function isRateLimited(request: Request, bucket: string): Promise<boolean> {
   const cache = defaultCache()
@@ -55,15 +94,16 @@ export async function isRateLimited(request: Request, bucket: string): Promise<b
 
   try {
     const existing = await cache.match(key)
-    const count = existing === undefined ? 0 : Number(await existing.text())
-    if (!Number.isFinite(count) || count >= LIMIT) {
-      return count >= LIMIT
+    const parsed = existing === undefined ? undefined : parseWindow(await existing.json())
+    const { limited, next, maxAge } = advanceWindow(parsed, Date.now())
+    if (limited) {
+      return true
     }
 
     await cache.put(
       key,
-      new Response(String(count + 1), {
-        headers: { 'Cache-Control': `max-age=${WINDOW_SEC}` },
+      Response.json(next, {
+        headers: { 'Cache-Control': `max-age=${maxAge}` },
       }),
     )
     return false

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,33 @@
+const WINDOW_SEC = 600
+const LIMIT = 5
+
+function clientIp(request: Request): string {
+  return request.headers.get('cf-connecting-ip') ?? request.headers.get('x-forwarded-for') ?? 'local'
+}
+
+/**
+ * Per-IP sliding window using the Worker Cache API. Fails open if Cache is
+ * unavailable (local Node prerender, missing caches).
+ */
+export async function isRateLimited(request: Request, bucket: string): Promise<boolean> {
+  const ip = clientIp(request)
+  const key = new Request(`https://rl.yagiz.co/${bucket}/${ip}`)
+
+  try {
+    const existing = await caches.default.match(key)
+    const count = existing === undefined ? 0 : Number(await existing.text())
+    if (!Number.isFinite(count) || count >= LIMIT) {
+      return count >= LIMIT
+    }
+
+    await caches.default.put(
+      key,
+      new Response(String(count + 1), {
+        headers: { 'Cache-Control': `max-age=${WINDOW_SEC}` },
+      }),
+    )
+    return false
+  } catch {
+    return false
+  }
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,8 +1,43 @@
 const WINDOW_SEC = 600
 const LIMIT = 5
 
+interface WorkerCache {
+  match: (request: Request) => Promise<Response | undefined>
+  put: (request: Request, response: Response) => Promise<void>
+}
+
 function clientIp(request: Request): string {
-  return request.headers.get('cf-connecting-ip') ?? request.headers.get('x-forwarded-for') ?? 'local'
+  return (
+    request.headers.get('cf-connecting-ip') ?? request.headers.get('x-forwarded-for') ?? 'local'
+  )
+}
+
+function defaultCache(): WorkerCache | undefined {
+  const store: unknown = Reflect.get(globalThis, 'caches')
+  if (typeof store !== 'object' || store === null) {
+    return undefined
+  }
+
+  const cache: unknown = Reflect.get(store, 'default')
+  if (typeof cache !== 'object' || cache === null) {
+    return undefined
+  }
+
+  const match: unknown = Reflect.get(cache, 'match')
+  const put: unknown = Reflect.get(cache, 'put')
+  if (typeof match !== 'function' || typeof put !== 'function') {
+    return undefined
+  }
+
+  return {
+    match: async (request) => {
+      const result: unknown = await match.call(cache, request)
+      return result instanceof Response ? result : undefined
+    },
+    put: async (request, response) => {
+      await put.call(cache, request, response)
+    },
+  }
 }
 
 /**
@@ -10,17 +45,22 @@ function clientIp(request: Request): string {
  * unavailable (local Node prerender, missing caches).
  */
 export async function isRateLimited(request: Request, bucket: string): Promise<boolean> {
+  const cache = defaultCache()
+  if (cache === undefined) {
+    return false
+  }
+
   const ip = clientIp(request)
   const key = new Request(`https://rl.yagiz.co/${bucket}/${ip}`)
 
   try {
-    const existing = await caches.default.match(key)
+    const existing = await cache.match(key)
     const count = existing === undefined ? 0 : Number(await existing.text())
     if (!Number.isFinite(count) || count >= LIMIT) {
       return count >= LIMIT
     }
 
-    await caches.default.put(
+    await cache.put(
       key,
       new Response(String(count + 1), {
         headers: { 'Cache-Control': `max-age=${WINDOW_SEC}` },

--- a/src/pages/[id]/index.astro
+++ b/src/pages/[id]/index.astro
@@ -30,6 +30,7 @@ import { seriesNeighbors } from '@/lib/series'
 
 interface Props {
   post: CollectionEntry<'blog'>
+  posts: CollectionEntry<'blog'>[]
 }
 
 export async function getStaticPaths(): Promise<ReturnType<GetStaticPaths>> {
@@ -38,11 +39,11 @@ export async function getStaticPaths(): Promise<ReturnType<GetStaticPaths>> {
 
   return posts.map((post) => ({
     params: { id: post.id },
-    props: { post },
+    props: { post, posts },
   }))
 }
 
-const { post } = Astro.props
+const { post, posts }: Props = Astro.props
 const { Content, headings } = await render(post)
 const tag = await getEntry(post.data.tag.collection, post.data.tag.id)
 if (!tag) {
@@ -51,8 +52,6 @@ if (!tag) {
 const words = countWords(post.body)
 const minute_to_read = readingTimeLabel(post.body)
 
-const collected = await getCollection('blog', ({ data }) => data.status === 'published')
-const posts = collected.toSorted((a, b) => b.data.date.getTime() - a.data.date.getTime())
 const index = posts.findIndex((p) => p.id === post.id)
 const suggestions = relatedPosts(post, posts)
 const relatedAreSameSeries = Boolean(
@@ -176,7 +175,7 @@ const neighbors = seriesNeighbors(post, posts)
     <Prose as="div" itemprop="articleBody">
       <Content {components} />
     </Prose>
-    <BlogFooter {index} />
+    <BlogFooter {index} {posts} />
   </article>
 
   {

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,44 +1,63 @@
 import type { APIRoute } from 'astro'
+
 import { env } from 'cloudflare:workers'
 
-const response = ({ status, message }: { status: number; message: string }): Response =>
-  Response.json(
-    { status, message },
-    {
-      status,
-      headers: { 'Content-Type': 'application/json' },
-    },
-  )
+import {
+  escapeHtml,
+  isEmail,
+  isHoneypot,
+  jsonResponse,
+  oneLine,
+  readJsonObject,
+  readString,
+  validateMessage,
+  validateSubject,
+} from '@/lib/form-api'
+import { isRateLimited } from '@/lib/rate-limit'
 
 export const POST: APIRoute = async ({ request }) => {
-  const body: {
-    email?: string
-    subject?: string
-    message?: string
-  } = await request.json()
-
-  if (!body.email?.length || !body.subject?.length || !body.message?.length) {
-    return response({
-      status: 400,
-      message: 'Input validation failed. Email, subject, and message are required.',
-    })
+  const body = await readJsonObject(request)
+  if (body === null) {
+    return jsonResponse(400, 'Invalid JSON body.')
   }
+
+  if (isHoneypot(readString(body, 'company'))) {
+    return jsonResponse(200, 'Message sent.')
+  }
+
+  if (await isRateLimited(request, 'contact')) {
+    return jsonResponse(429, 'Too many requests. Please try again later.')
+  }
+
+  const email = readString(body, 'email')
+  const subject = oneLine(readString(body, 'subject'))
+  const message = readString(body, 'message')
+
+  if (!isEmail(email) || !validateSubject(subject) || !validateMessage(message)) {
+    return jsonResponse(
+      400,
+      'Input validation failed. Email, subject, and message are required.',
+    )
+  }
+
+  const safeEmail = escapeHtml(email)
+  const safeMessage = escapeHtml(message).replaceAll('\n', '<br>')
 
   try {
     await env.email.send({
       to: 'yagiz@nizipli.com',
       from: 'contact@newsletter.yagiz.co',
-      replyTo: body.email,
-      subject: body.subject,
-      text: `From: ${body.email}\n\n${body.message}`,
-      html: `<p><strong>From:</strong> ${body.email}</p><br><p>${body.message.replaceAll('\n', '<br>')}</p>`,
+      replyTo: email,
+      subject,
+      text: `From: ${email}\n\n${message}`,
+      html: `<p><strong>From:</strong> ${safeEmail}</p><br><p>${safeMessage}</p>`,
     })
   } catch (error) {
     console.error('Failed to send contact email:', error)
-    return response({ status: 500, message: 'Failed to send message. Please try again.' })
+    return jsonResponse(500, 'Failed to send message. Please try again.')
   }
 
-  return response({ status: 200, message: 'Message sent.' })
+  return jsonResponse(200, 'Message sent.')
 }
 
 export const prerender = false

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,5 +1,4 @@
 import type { APIRoute } from 'astro'
-
 import { env } from 'cloudflare:workers'
 
 import {
@@ -34,10 +33,7 @@ export const POST: APIRoute = async ({ request }) => {
   const message = readString(body, 'message')
 
   if (!isEmail(email) || !validateSubject(subject) || !validateMessage(message)) {
-    return jsonResponse(
-      400,
-      'Input validation failed. Email, subject, and message are required.',
-    )
+    return jsonResponse(400, 'Input validation failed. Email, subject, and message are required.')
   }
 
   const safeEmail = escapeHtml(email)

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -20,7 +20,7 @@ export const POST: APIRoute = async ({ request }) => {
     return jsonResponse(400, 'Invalid JSON body.')
   }
 
-  if (isHoneypot(readString(body, 'company'))) {
+  if (isHoneypot(readString(body, 'website_url'))) {
     return jsonResponse(200, 'Message sent.')
   }
 

--- a/src/pages/api/newsletter.ts
+++ b/src/pages/api/newsletter.ts
@@ -17,7 +17,7 @@ export const POST: APIRoute = async ({ request }) => {
     return jsonResponse(400, 'Invalid JSON body.')
   }
 
-  if (isHoneypot(readString(body, 'company'))) {
+  if (isHoneypot(readString(body, 'website_url'))) {
     return jsonResponse(200, 'Added you to the newsletter. Thank you for signing up.')
   }
 

--- a/src/pages/api/newsletter.ts
+++ b/src/pages/api/newsletter.ts
@@ -1,5 +1,4 @@
 import type { APIRoute } from 'astro'
-
 import { env } from 'cloudflare:workers'
 
 import {
@@ -30,10 +29,7 @@ export const POST: APIRoute = async ({ request }) => {
   const name = readString(body, 'name')
 
   if (!isEmail(email) || !validateName(name)) {
-    return jsonResponse(
-      400,
-      'Input validation failed. Make sure you have an email and a full name',
-    )
+    return jsonResponse(400, 'Input validation failed. Make sure you have an email and a full name')
   }
 
   try {

--- a/src/pages/api/newsletter.ts
+++ b/src/pages/api/newsletter.ts
@@ -1,39 +1,52 @@
 import type { APIRoute } from 'astro'
+
 import { env } from 'cloudflare:workers'
 
-const response = ({ status, message }: { status: number; message: string }): Response =>
-  Response.json(
-    { status, message },
-    {
-      status,
-      headers: { 'Content-Type': 'application/json' },
-    },
-  )
+import {
+  isEmail,
+  isHoneypot,
+  jsonResponse,
+  readJsonObject,
+  readString,
+  validateName,
+} from '@/lib/form-api'
+import { isRateLimited } from '@/lib/rate-limit'
 
 export const POST: APIRoute = async ({ request }) => {
-  const body: { email?: string; name?: string } = await request.json()
+  const body = await readJsonObject(request)
+  if (body === null) {
+    return jsonResponse(400, 'Invalid JSON body.')
+  }
 
-  if (!body.email?.length || !body.name?.length) {
-    return response({
-      status: 400,
-      message: 'Input validation failed. Make sure you have an email and a full name',
-    })
+  if (isHoneypot(readString(body, 'company'))) {
+    return jsonResponse(200, 'Added you to the newsletter. Thank you for signing up.')
+  }
+
+  if (await isRateLimited(request, 'newsletter')) {
+    return jsonResponse(429, 'Too many requests. Please try again later.')
+  }
+
+  const email = readString(body, 'email')
+  const name = readString(body, 'name')
+
+  if (!isEmail(email) || !validateName(name)) {
+    return jsonResponse(
+      400,
+      'Input validation failed. Make sure you have an email and a full name',
+    )
   }
 
   try {
     await env.newsletter
       .prepare('INSERT INTO subscribers (email, name) VALUES (?, ?) ON CONFLICT (email) DO NOTHING')
-      .bind(body.email, body.name)
+      .bind(email, name)
       .run()
   } catch (error) {
     console.error('Failed to insert subscriber into D1:', error)
-    return response({ status: 500, message: 'Failed to register. Please try again.' })
+    return jsonResponse(500, 'Failed to register. Please try again.')
   }
 
-  return response({
-    status: 200,
-    message: 'Added you to the newsletter. Thank you for signing up.',
-  })
+  return jsonResponse(200, 'Added you to the newsletter. Thank you for signing up.')
 }
 
 export const prerender = false

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,6 +37,7 @@ const markdownUrl = `${websiteUrl}/index.md`
           src={familyImg}
           width={150}
           height={150}
+          layout="fixed"
           loading="eager"
           fetchpriority="high"
           class="rounded-full"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,7 +3,7 @@
 @config "../../tailwind.config.mjs";
 
 :root {
-  color-scheme: dark;
+  color-scheme: light dark;
 }
 
 body {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
---
type: feature
intent: Harden public form APIs, add node:test plus a CI build job, and apply leftover image, theme, type, and Dependabot cleanups.
app-source-changed: true
constraints: typescript@6, markdown-processor: satteri, no vitest, no turnstile, @astrojs/compiler-rs@0.3.2
verify:
  - node --run lint
  - node --run test
  - node --run build
preview: https://cursor-repo-improvements-b6e5-yagiz.nizipli.workers.dev
---

## Summary

Implements the leftover improvement list after the oxlint and Astro 7 Sätteri work.

- `/api/contact` and `/api/newsletter` now reject invalid JSON (`400`), validate emails and field lengths, treat a filled `website_url` honeypot as a fake `200`, and rate-limit 5 requests / 10 minutes / IP via a **fixed** Cache API window (fail open). Contact mail HTML-escapes `email` / `message` and strips CR/LF from `subject`.
- `node:test` covers `src/lib/accept.ts`, `src/lib/form-api.ts`, and `src/lib/rate-limit.ts`. CI adds `.github/workflows/build.yml` (`pnpm run test` then `pnpm run build`).
- Astro `image.responsiveStyles: true` with `layout="fixed"` on avatars and `layout="constrained"` on post / MDX images.
- `color-scheme: light dark`, typed `Astro.props` on Container / Prose / Figure, dropped the stale `types.ts` triple-slash, pass published posts from `getStaticPaths` into `BlogFooter` instead of a third `getCollection`, and remove the unimplemented CLI sponsorship stub.
- Dependabot ignores `@biomejs/biome` and `@astrojs/compiler-rs >=0.4.0`. Stale Dependabot PRs #191, #192, #193, #194, and #195 are closed as obsolete.

## Non-goals

- No Turnstile (needs dashboard keys).
- No Vitest, `src/fetch.ts`, incremental builds, View Transitions, or Actions.
- No `@astrojs/compiler-rs` 0.4, TypeScript 7, or Biome.
- Do not invent a sponsorships CLI feature.

## Test plan

- [x] `node --run lint`
- [x] `node --run test`
- [x] `node --run build`
- [x] `POST /api/contact` with invalid JSON → `400` + `Cache-Control: no-store`
- [x] `POST /api/contact` with `website_url` set → `200` (honeypot, no email send)
- [x] `POST /api/contact` with markup in `message` → HTML is escaped (unit test + local POST)
- [x] `POST /api/newsletter` with a bad email → `400`
- [x] Homepage avatar and blog footer author image keep fixed circular sizes
- [x] Contact and newsletter forms still submit; honeypot field is off-screen
- [x] LLM surfaces (Worker / Accept / sitemap unchanged except API hardening):
  - [x] `GET /llms.txt` → `200 text/plain`
  - [x] `GET /llms-full.txt` → `200 text/plain`
  - [x] `GET /about.md` → YAML frontmatter + `X-Robots-Tag: noindex`
  - [x] `Accept: text/markdown` on `/about` → `Content-Type: text/markdown` + `Vary: Accept`
  - [x] HTML response has `Link: rel="alternate"; type="text/markdown"`
  - [x] `Accept: application/pdf` → `406`
  - [x] sitemap lists HTML only (no `.md` / `llms*.txt`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

