### PR TITLE
Move View as Markdown links to the end of the page

### DIFF
--- a/src/components/MarkdownLink.astro
+++ b/src/components/MarkdownLink.astro
@@ -4,13 +4,13 @@ interface Props {
   class?: string
 }
 
-const { href, class: className } = Astro.props
+const { href, class: className }: Props = Astro.props
 ---
 
 <a
   href={href}
   class:list={[
-    'text-xs font-bold text-neutral-500 hover:text-neutral-400 dark:text-neutral-500 dark:hover:text-neutral-400',
+    'rounded text-xs font-bold text-neutral-500 hover:text-neutral-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 dark:text-neutral-500 dark:hover:text-neutral-400',
     className,
   ]}
 >

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,10 +1,17 @@
 ---
+import MarkdownLink from '@/components/MarkdownLink.astro'
 import { rssUrl, xUrl } from '@/lib/content'
+
+interface Props {
+  markdownUrl?: string
+}
 
 export interface Item {
   title: string
   href: string
 }
+
+const { markdownUrl }: Props = Astro.props
 
 const footerItems: (Item & { label?: string })[] = [
   { title: 'About', href: '/about' },
@@ -38,4 +45,5 @@ const footerItems: (Item & { label?: string })[] = [
       ))
     }
   </nav>
+  {markdownUrl && <MarkdownLink href={markdownUrl} />}
 </footer>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -159,6 +159,6 @@ const googlebot = noindex
       <slot />
     </main>
     <CodeCopy />
-    <Footer />
+    <Footer markdownUrl={markdownUrl} />
   </body>
 </html>

--- a/src/pages/[id]/index.astro
+++ b/src/pages/[id]/index.astro
@@ -7,7 +7,6 @@ import BlogFooter from '@/components/BlogFooter.astro'
 import BlogRow from '@/components/BlogRow.astro'
 import BlogStickyHeader from '@/components/BlogStickyHeader.astro'
 import Breadcrumbs from '@/components/Breadcrumbs.astro'
-import MarkdownLink from '@/components/MarkdownLink.astro'
 import { components } from '@/components/mdx'
 import SeriesNav from '@/components/SeriesNav.astro'
 import TableOfContents from '@/components/TableOfContents.astro'
@@ -141,9 +140,6 @@ const neighbors = seriesNeighbors(post, posts)
             {tag.data.title}
           </a>
         </span>
-      </div>
-      <div class="col-main mb-4">
-        <MarkdownLink href={markdownUrl} />
       </div>
 
       <Heading itemprop="headline">{post.data.title}</Heading>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,5 @@
 ---
 import { getEntry } from 'astro:content'
-import MarkdownLink from '@/components/MarkdownLink.astro'
 import Page from '@/components/Page.astro'
 import Layout from '@/layouts/Layout.astro'
 import { authorFullName, websiteUrl } from '@/lib/content'
@@ -36,7 +35,4 @@ const breadcrumbs = pageBreadcrumbs(page.data.title, '/about')
       <link itemprop="url" href={websiteUrl} />
     </div>
   </Page>
-  <div class="mx-auto mt-8 max-w-[calc(750px+8vw)] px-[4vw] text-center">
-    <MarkdownLink href={markdownUrl} />
-  </div>
 </Layout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,7 +1,6 @@
 ---
 import { getEntry } from 'astro:content'
 import ContactForm from '@/components/ContactForm.astro'
-import MarkdownLink from '@/components/MarkdownLink.astro'
 import Page from '@/components/Page.astro'
 import Layout from '@/layouts/Layout.astro'
 import { websiteUrl } from '@/lib/content'
@@ -30,7 +29,4 @@ const breadcrumbs = pageBreadcrumbs(page.data.title, '/contact')
   >
     <ContactForm />
   </Page>
-  <div class="mx-auto mt-8 max-w-[calc(750px+8vw)] px-[4vw] text-center">
-    <MarkdownLink href={markdownUrl} />
-  </div>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,6 @@ import { Image } from 'astro:assets'
 import { getCollection } from 'astro:content'
 import familyImg from '@/assets/family.png'
 import BlogRow from '@/components/BlogRow.astro'
-import MarkdownLink from '@/components/MarkdownLink.astro'
 import SubscribeButton from '@/components/SubscribeButton.astro'
 import Container from '@/components/ui/Container.astro'
 import Layout from '@/layouts/Layout.astro'
@@ -57,7 +56,6 @@ const markdownUrl = `${websiteUrl}/index.md`
       </div>
 
       <SubscribeButton />
-      <MarkdownLink href={markdownUrl} class="mt-4" />
     </div>
     <div
       class="pt-8"

--- a/src/pages/newsletter.astro
+++ b/src/pages/newsletter.astro
@@ -1,6 +1,5 @@
 ---
 import { getEntry } from 'astro:content'
-import MarkdownLink from '@/components/MarkdownLink.astro'
 import NewsletterForm from '@/components/NewsletterForm.astro'
 import Page from '@/components/Page.astro'
 import Layout from '@/layouts/Layout.astro'
@@ -30,7 +29,4 @@ const breadcrumbs = pageBreadcrumbs(page.data.title, '/newsletter')
   >
     <NewsletterForm />
   </Page>
-  <div class="mx-auto mt-8 max-w-[calc(750px+8vw)] px-[4vw] text-center">
-    <MarkdownLink href={markdownUrl} />
-  </div>
 </Layout>

--- a/src/pages/press.astro
+++ b/src/pages/press.astro
@@ -1,6 +1,5 @@
 ---
 import { getEntry } from 'astro:content'
-import MarkdownLink from '@/components/MarkdownLink.astro'
 import Page from '@/components/Page.astro'
 import Layout from '@/layouts/Layout.astro'
 import { websiteUrl } from '@/lib/content'
@@ -27,7 +26,4 @@ const breadcrumbs = pageBreadcrumbs(page.data.title, '/press')
     itemid={absoluteUrl('/press')}
     breadcrumbs={breadcrumbs}
   />
-  <div class="mx-auto mt-8 max-w-[calc(750px+8vw)] px-[4vw] text-center">
-    <MarkdownLink href={markdownUrl} />
-  </div>
 </Layout>

--- a/src/pages/tag/[id].astro
+++ b/src/pages/tag/[id].astro
@@ -4,7 +4,6 @@ import type { CollectionEntry } from 'astro:content'
 import type { GetStaticPaths } from 'astro'
 import BlogRow from '@/components/BlogRow.astro'
 import Breadcrumbs from '@/components/Breadcrumbs.astro'
-import MarkdownLink from '@/components/MarkdownLink.astro'
 import Container from '@/components/ui/Container.astro'
 import Layout from '@/layouts/Layout.astro'
 import { websiteUrl } from '@/lib/content'
@@ -61,8 +60,6 @@ const crumbs = tagBreadcrumbs(tag)
           ))
         }
       </div>
-
-      <MarkdownLink href={markdownUrl} />
     </Container>
 
     <div

--- a/src/pages/url-parsing.astro
+++ b/src/pages/url-parsing.astro
@@ -2,7 +2,6 @@
 import { getCollection } from 'astro:content'
 import BlogRow from '@/components/BlogRow.astro'
 import Breadcrumbs from '@/components/Breadcrumbs.astro'
-import MarkdownLink from '@/components/MarkdownLink.astro'
 import Container from '@/components/ui/Container.astro'
 import Layout from '@/layouts/Layout.astro'
 import { websiteUrl } from '@/lib/content'
@@ -28,7 +27,6 @@ const crumbs = seriesBreadcrumbs(series.title, series.path)
       <Breadcrumbs items={crumbs} />
       <h1 class="text-2xl font-extrabold text-orange-400" itemprop="name">{series.title}</h1>
       <div class="leading-6 dark:text-white" itemprop="description">{series.description}</div>
-      <MarkdownLink href={markdownUrl} />
     </Container>
 
     <div


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
---
type: chore
intent: Move the visible View as Markdown control from page headers and heroes to the site footer so it sits at the end of every page.
app-source-changed: true
constraints: typescript@6, markdown-processor: satteri
verify:
  - node --run lint
  - node --run build
preview: https://cursor-markdown-link-end-b6e5-yagiz.nizipli.workers.dev
---

## Summary

`Layout` already receives `markdownUrl` for `<link rel="alternate" type="text/markdown">`. The visible **View as Markdown** control now renders once in the footer, after the footer nav, on every page that has a markdown sibling.

Removed the per-page `MarkdownLink` placements from the homepage hero, blog post header, tag and series headers, and the extra wrappers on About / Contact / Newsletter / Press.

404 still has no markdown sibling, so it still has no button.

## Non-goals

- No change to Accept negotiation, `.md` routes, `llms.txt`, or sitemap.
- Footer nav items are unchanged.

## Test plan

- [x] `node --run lint`
- [x] `node --run build`
- [x] Home, a blog post, `/about`, `/contact`, `/tag/performance`, `/url-parsing` show **View as Markdown** only in the footer (not in the hero or article header)
- [x] Footer link goes to the correct `.md` sibling
- [x] 404 has no View as Markdown link
- [x] LLM surfaces:
  - [x] `GET /llms.txt` → `200 text/plain`
  - [x] `GET /llms-full.txt` → `200 text/plain`
  - [x] `GET /about.md` → YAML frontmatter + `X-Robots-Tag: noindex`
  - [x] `Accept: text/markdown` on `/about` → `Content-Type: text/markdown` + `Vary: Accept`
  - [x] HTML response has `Link: rel="alternate"; type="text/markdown"`
  - [x] `Accept: application/pdf` → `406`
  - [x] sitemap lists HTML only (no `.md` / `llms*.txt`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b60-1c91-73a0-8c8f-6ca7e05db6e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

